### PR TITLE
chore: eliminación de memoización manual

### DIFF
--- a/excursiones/babel.config.js
+++ b/excursiones/babel.config.js
@@ -1,0 +1,12 @@
+// babel.config.js
+module.exports = {
+    presets: [
+        // Tus otros presets, como @babel/preset-env, @babel/preset-react, etc.
+        // Por ejemplo, en un proyecto Create React App sería 'babel-preset-react-app'
+        "babel-preset-react-app",
+    ],
+    plugins: [
+        // Añade el plugin de React Compiler aquí
+        "babel-plugin-react-compiler",
+    ],
+};

--- a/excursiones/package-lock.json
+++ b/excursiones/package-lock.json
@@ -25,8 +25,13 @@
 				"web-vitals": "^1.1.2"
 			},
 			"devDependencies": {
+				"babel-plugin-react-compiler": "^1.0.0",
 				"eslint-plugin-jsdoc": "^60.5.0",
 				"redux-mock-store": "^1.5.5"
+			},
+			"engines": {
+				"node": "22.9.0",
+				"npm": "11.6.0"
 			}
 		},
 		"node_modules/@adobe/css-tools": {
@@ -6378,6 +6383,16 @@
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+			}
+		},
+		"node_modules/babel-plugin-react-compiler": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-react-compiler/-/babel-plugin-react-compiler-1.0.0.tgz",
+			"integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^7.26.0"
 			}
 		},
 		"node_modules/babel-plugin-transform-react-remove-prop-types": {

--- a/excursiones/package.json
+++ b/excursiones/package.json
@@ -51,6 +51,7 @@
 		"react-error-overlay": "6.0.10"
 	},
 	"devDependencies": {
+		"babel-plugin-react-compiler": "^1.0.0",
 		"eslint-plugin-jsdoc": "^60.5.0",
 		"redux-mock-store": "^1.5.5"
 	}

--- a/excursiones/src/components/ExcursionCard/ExcursionCard.js
+++ b/excursiones/src/components/ExcursionCard/ExcursionCard.js
@@ -1,4 +1,4 @@
-import React, { memo, useCallback, useId, useState, useEffect } from "react";
+import React, { useId, useState, useEffect } from "react";
 import { Card, Alert } from "react-bootstrap";
 import ExcursionDetailItem from "../ExcursionDetailItem";
 import StyledButton from "../StyledButton";
@@ -50,7 +50,7 @@ const getDifficultyClasses = (difficultyLevel) => {
  * @param {JoinButtonProps} props - Las propiedades del componente.
  * @returns {React.ReactElement} - El elemento React que representa el botón o estado.
  */
-function JoinButtonComponent({ isJoined, isJoining, onJoin }) {
+function JoinButton({ isJoined, isJoining, onJoin }) {
 	if (isJoined) {
 		return (
 			<div className="d-grid d-md-flex justify-content-center justify-content-md-end">
@@ -74,8 +74,6 @@ function JoinButtonComponent({ isJoined, isJoining, onJoin }) {
 	);
 }
 
-const JoinButton = memo(JoinButtonComponent);
-
 /**
  * @typedef {object} ExcursionCardProps
  * @property {string | number} id - El ID de la excursión.
@@ -94,7 +92,7 @@ const JoinButton = memo(JoinButtonComponent);
  * @param {ExcursionCardProps} props - Las propiedades del componente.
  * @returns {React.ReactElement} El elemento React que representa la tarjeta de excursión.
  */
-function ExcursionCardComponent({
+function ExcursionCard({
 	id,
 	name,
 	area,
@@ -118,10 +116,9 @@ function ExcursionCardComponent({
 	// Genera un ID seguro para el título, que se usará para la accesibilidad, previniendo inyección de atributos.
 	const titleId = useId();
 
-	// Callback memoizado para manejar el evento de unirse a la excursión.
-	const handleOnJoin = useCallback(() => {
+	const handleOnJoin = () => {
 		handleJoin(id);
-	}, [handleJoin, id]);
+	};
 
 	// Efecto para anunciar cambios de estado a los lectores de pantalla.
 	useEffect(() => {
@@ -228,5 +225,4 @@ function ExcursionCardComponent({
 	);
 }
 
-const ExcursionCard = memo(ExcursionCardComponent);
 export default ExcursionCard;

--- a/excursiones/src/components/ExcursionDetailItem/ExcursionDetailItem.js
+++ b/excursiones/src/components/ExcursionDetailItem/ExcursionDetailItem.js
@@ -1,4 +1,4 @@
-import React, { memo, useCallback } from "react";
+import React from "react";
 import { OverlayTrigger, Tooltip } from "react-bootstrap";
 import styles from "./ExcursionDetailItem.module.css";
 
@@ -13,29 +13,20 @@ import styles from "./ExcursionDetailItem.module.css";
  * debe ser sanitizado para prevenir ataques XSS.
  * @returns {React.ReactElement} - El elemento React que representa el detalle de la excursión.
  */
-function ExcursionDetailItemComponent({
-	IconComponent,
-	text,
-	label,
-	children,
-}) {
+function ExcursionDetailItem({ IconComponent, text, label, children }) {
 	/**
 	 * Renderiza el Tooltip para el detalle de la excursión.
-	 * Se memoiza con `useCallback` para evitar que se recree en cada renderizado.
 	 * @param {object} props - Propiedades inyectadas por OverlayTrigger.
-	 * @returns {React.ReactElement}
+	 * @returns {React.ReactElement} - El elemento Tooltip.
 	 */
-	const renderTooltip = useCallback(
-		(props) => (
-			<Tooltip {...props}>{label ? `${label}: ${text}` : text}</Tooltip>
-		),
-		[label, text]
+	const renderTooltip = (props) => (
+		<Tooltip {...props}>{label ? `${label}: ${text}` : text}</Tooltip>
 	);
 
 	// Si no hay texto ni hijos para mostrar, no renderizamos nada.
 	// Esta comprobación se hace DESPUÉS de los hooks para cumplir las reglas de los hooks.
 	if (!text && !children) {
-		return null;
+		return null; // No renderizar nada si no hay contenido.
 	}
 
 	const itemContent = (
@@ -63,5 +54,4 @@ function ExcursionDetailItemComponent({
 	);
 }
 
-const ExcursionDetailItem = memo(ExcursionDetailItemComponent);
 export default ExcursionDetailItem;

--- a/excursiones/src/components/ExcursionsList/ExcursionsList.js
+++ b/excursiones/src/components/ExcursionsList/ExcursionsList.js
@@ -1,11 +1,4 @@
-import React, {
-	useMemo,
-	memo,
-	useCallback,
-	useState,
-	useEffect,
-	useRef,
-} from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { Row, Col } from "react-bootstrap";
 import { useSelector, useDispatch } from "react-redux";
 import { updateUser } from "../../slices/loginSlice";
@@ -29,7 +22,7 @@ import styles from "./ExcursionsList.module.css";
  * @param {Error | null} props.error - Objeto de error si ha ocurrido un problema al cargar las excursiones. Se evalúa su veracidad.
  * @returns {React.ReactElement} El componente de la lista de excursiones.
  */
-function ExcursionsListComponent({ excursionData = [], isLoading, error }) {
+function ExcursionsList({ excursionData = [], isLoading, error }) {
 	// Se obtiene el estado del loginReducer, el objeto usuario y el token
 	const {
 		login: isLoggedIn,
@@ -80,71 +73,59 @@ function ExcursionsListComponent({ excursionData = [], isLoading, error }) {
 	 * Función asíncrona para unirse a una excursión.
 	 * @param {string | number} excursionId - El ID de la excursión a la que el usuario desea unirse.
 	 */
-	const joinExcursion = useCallback(
-		async (excursionId) => {
-			try {
-				// Llamada al servicio para unirse a la excursión.
-				const updatedUser = await joinExcursionService(
-					user?.mail,
-					excursionId,
-					token
-				);
-				// Actualiza el estado global del usuario con la nueva información.
-				loginDispatch(updateUser({ user: updatedUser }));
-			} catch (caughtError) {
-				// En desarrollo, muestra el error completo para facilitar la depuración.
-				if (process.env.NODE_ENV === "development") {
-					console.error("Error detallado (dev):", caughtError);
-				} else {
-					// En producción o test, registramos un mensaje controlado para no exponer detalles.
-					console.error(
-						"Error técnico al unirse a la excursión:",
-						caughtError.message || "Error desconocido"
-					);
-				}
-				// Relanzamos un nuevo error con un mensaje más amigable para el usuario.
-				// Este error será capturado y mostrado por el componente ExcursionCard.
-				throw new Error(
-					"No ha sido posible apuntarse a la excursión. Por favor, inténtalo de nuevo más tarde."
+	const joinExcursion = async (excursionId) => {
+		try {
+			// Llamada al servicio para unirse a la excursión.
+			const updatedUser = await joinExcursionService(
+				user?.mail,
+				excursionId,
+				token
+			);
+			// Actualiza el estado global del usuario con la nueva información.
+			loginDispatch(updateUser({ user: updatedUser }));
+		} catch (caughtError) {
+			// En desarrollo, muestra el error completo para facilitar la depuración.
+			if (process.env.NODE_ENV === "development") {
+				console.error("Error detallado (dev):", caughtError);
+			} else {
+				// En producción o test, registramos un mensaje controlado para no exponer detalles.
+				console.error(
+					"Error técnico al unirse a la excursión:",
+					caughtError.message || "Error desconocido"
 				);
 			}
-		},
-		// `token` se añade como dependencia para asegurar que la función tiene la versión más reciente.
-		[user?.mail, token, loginDispatch]
-	);
+			// Relanzamos un nuevo error con un mensaje más amigable para el usuario.
+			// Este error será capturado y mostrado por el componente ExcursionCard.
+			throw new Error(
+				"No ha sido posible apuntarse a la excursión. Por favor, inténtalo de nuevo más tarde."
+			);
+		}
+	};
 
 	/**
-	 * Componentes de las tarjetas de excursión, memoizados para optimizar el rendimiento, ya que el mapear un array a
-	 * componentes puede ser costoso si hay muchas excursiones.
-	 * Cada tarjeta recibe las propiedades necesarias y se encarga de mostrar la información de la excursión.
-	 * Además, se comprueba si el usuario ha iniciado sesión y si ya está apuntado a la excursión para mostrar el botón
-	 * de unirse o no.
+	 * Componentes de las tarjetas de excursión. El compilador de React se encargará de memoizar este cálculo si es necesario.
 	 */
-	const excursionComponents = useMemo(
-		() =>
-			displayedExcursions.map((excursion) => {
-				const isJoined = isLoggedIn && user?.excursions?.includes(excursion.id);
-				return (
-					<Col
-						as="li"
-						xs={12}
-						md={6}
-						lg={4}
-						key={excursion.id}
-						xl={3}
-						className="d-flex" // d-flex para que las cards se estiren y ocupen toda la altura
-					>
-						<ExcursionCard
-							{...excursion}
-							isLoggedIn={isLoggedIn}
-							isJoined={isJoined}
-							onJoin={joinExcursion}
-						/>
-					</Col>
-				);
-			}),
-		[displayedExcursions, isLoggedIn, user?.excursions, joinExcursion]
-	);
+	const excursionComponents = displayedExcursions.map((excursion) => {
+		const isJoined = isLoggedIn && user?.excursions?.includes(excursion.id);
+		return (
+			<Col
+				as="li"
+				xs={12}
+				md={6}
+				lg={4}
+				key={excursion.id}
+				xl={3}
+				className="d-flex" // d-flex para que las cards se estiren y ocupen toda la altura
+			>
+				<ExcursionCard
+					{...excursion}
+					isLoggedIn={isLoggedIn}
+					isJoined={isJoined}
+					onJoin={joinExcursion}
+				/>
+			</Col>
+		);
+	});
 
 	// --- Lógica de Renderizado Condicional ---
 	// Si hay un error, mostrar el componente de error.
@@ -173,5 +154,4 @@ function ExcursionsListComponent({ excursionData = [], isLoading, error }) {
 	);
 }
 
-const ExcursionsList = memo(ExcursionsListComponent);
 export default ExcursionsList;

--- a/excursiones/src/components/ExcursionsList/ExcursionsLoading/ExcursionsLoading.js
+++ b/excursiones/src/components/ExcursionsList/ExcursionsLoading/ExcursionsLoading.js
@@ -1,4 +1,4 @@
-import React, { memo } from "react";
+import React from "react";
 import { useSelector } from "react-redux";
 import { Row, Col } from "react-bootstrap";
 import { SkeletonTheme } from "react-loading-skeleton";
@@ -10,9 +10,9 @@ import styles from "./ExcursionsLoading.module.css";
 
 /**
  * Componente para mostrar el esqueleto mientras las excursiones se cargan.
- * @returns {React.ReactElement} Componente de carga de excursiones.
+ * @returns {React.ReactElement} - Componente de carga de excursiones.
  */
-const ExcursionsLoadingComponent = () => {
+const ExcursionsLoading = () => {
 	const isLoggedIn = useSelector(
 		/**
 		 * @param {RootState} state - El estado global de Redux.
@@ -49,5 +49,4 @@ const ExcursionsLoadingComponent = () => {
 	);
 };
 
-const ExcursionsLoading = memo(ExcursionsLoadingComponent);
 export default ExcursionsLoading;

--- a/excursiones/src/components/ExcursionsList/NoExcursionsFound/NoExcursionsFound.js
+++ b/excursiones/src/components/ExcursionsList/NoExcursionsFound/NoExcursionsFound.js
@@ -1,4 +1,4 @@
-import React, { memo } from "react";
+import React from "react";
 import { FiSearch } from "react-icons/fi";
 import styles from "./NoExcursionsFound.module.css";
 
@@ -6,7 +6,7 @@ import styles from "./NoExcursionsFound.module.css";
  * Componente que muestra un mensaje cuando no se encuentran excursiones que coincidan con los criterios de búsqueda.
  * @returns {React.ReactElement} - Componente que indica que no se encontraron excursiones.
  */
-const NoExcursionsFoundComponent = () => (
+const NoExcursionsFound = () => (
 	<div className={styles.excursionsContainer}>
 		<output aria-live="polite" className={styles.messageNotFound}>
 			<FiSearch className={styles.messageIcon} aria-hidden="true" />
@@ -20,5 +20,4 @@ const NoExcursionsFoundComponent = () => (
 	</div>
 );
 
-const NoExcursionsFound = memo(NoExcursionsFoundComponent);
 export default NoExcursionsFound;

--- a/excursiones/src/components/ExcursionsPage/ExcursionsPage.js
+++ b/excursiones/src/components/ExcursionsPage/ExcursionsPage.js
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from "react";
+import React, { useState } from "react";
 import { Col, Button, Offcanvas, Badge } from "react-bootstrap";
 import { useSelector } from "react-redux";
 import { FiFilter } from "react-icons/fi";
@@ -22,15 +22,15 @@ const ExcursionsPage = ({ excursionsState }) => {
 	 */
 	const [showFilters, setShowFilters] = useState(false);
 	/**
-	 * Cierra el menú de filtros. Memoizada con `useCallback`.
+	 * Cierra el menú de filtros.
 	 * @type {() => void}
 	 */
-	const handleCloseFilters = useCallback(() => setShowFilters(false), []);
+	const handleCloseFilters = () => setShowFilters(false);
 	/**
-	 * Muestra el menú de filtros. Memoizada con `useCallback`.
+	 * Muestra el menú de filtros.
 	 * @type {() => void}
 	 */
-	const handleShowFilters = useCallback(() => setShowFilters(true), []);
+	const handleShowFilters = () => setShowFilters(true);
 
 	/**
 	 * Calcula el número total de filtros activos (área, dificultad, tiempo) desde el estado de Redux.

--- a/excursiones/src/components/FilterError/FilterError.js
+++ b/excursiones/src/components/FilterError/FilterError.js
@@ -1,14 +1,15 @@
-import { memo } from "react";
+import React from "react";
 import { FiAlertTriangle } from "react-icons/fi";
 import styles from "./FilterError.module.css";
 
 /**
  * Componente para mostrar un mensaje de error cuando falla la carga de los filtros.
- * @param {FilterErrorProps} props
+ * @param {FilterErrorProps} props - Props del componente.
  * @typedef {object} FilterErrorProps
  * @property {(Error & { secondaryMessage?: string }) | null} [error] - El objeto de error.
+ * @returns {React.ReactElement} - Componente de error de filtro.
  */
-function FilterErrorComponent({ error }) {
+function FilterError({ error }) {
 	const message =
 		error?.message || "No se pudieron cargar los filtros. Inténtalo de nuevo.";
 	const secondaryMessage = error?.secondaryMessage;
@@ -32,7 +33,5 @@ function FilterErrorComponent({ error }) {
 		</div>
 	);
 }
-
-const FilterError = memo(FilterErrorComponent);
 
 export default FilterError;

--- a/excursiones/src/components/Filters/Filters.js
+++ b/excursiones/src/components/Filters/Filters.js
@@ -1,4 +1,4 @@
-import { memo, useCallback } from "react";
+import React from "react";
 import { Button } from "react-bootstrap";
 import { useDispatch, useSelector } from "react-redux";
 import FiltersList from "../FiltersList/FilterList";
@@ -27,16 +27,17 @@ const filterSections = [
 	},
 ];
 
-/** @typedef {object} FiltersProps
+/**
+ * @typedef {object} FiltersProps
  * @property {boolean} [showTitle=true] - Controla si se muestra el título o no.
  */
 
-/** * Componente principal de los filtros que renderiza el tipo de los filtros de búsqueda (zona, dificultad, tiempo estimado).
- * Utiliza Redux para manejar el estado.
+/**
+ * Componente principal de los filtros que renderiza el tipo de los filtros de búsqueda (zona, dificultad, tiempo estimado).
  * @param {FiltersProps} props - Propiedades del componente.
- * @returns {React.ReactElement} El componente de filtros.
+ * @returns {React.ReactElement} - El componente de filtros.
  */
-function FiltersComponent({ showTitle = true }) {
+function Filters({ showTitle = true }) {
 	const dispatch = useDispatch();
 	/**
 	 * Comprueba si hay algún filtro activo para habilitar/deshabilitar el botón de limpiar filtros.
@@ -45,7 +46,10 @@ function FiltersComponent({ showTitle = true }) {
 	 * @type {boolean}
 	 */
 	const hasActiveFilters = useSelector(
-		/** @param {RootState} state */
+		/**
+		 * @param {RootState} state - El estado global de Redux.
+		 * @returns {boolean} - Verdadero si hay algún filtro activo, falso en caso contrario.
+		 */
 		(state) =>
 			state.filterReducer.area.length > 0 ||
 			state.filterReducer.difficulty.length > 0 ||
@@ -56,11 +60,11 @@ function FiltersComponent({ showTitle = true }) {
 	 * Maneja el evento de click para limpiar todos los filtros. Despacha la acción `clearAllFilters` al store de Redux.
 	 * @returns {void}
 	 */
-	const handleClearFilters = useCallback(() => {
+	const handleClearFilters = () => {
 		if (hasActiveFilters) {
 			dispatch(clearAllFilters());
 		}
-	}, [dispatch, hasActiveFilters]);
+	};
 
 	return (
 		// El contenedor principal usa flexbox para posicionar el footer abajo.
@@ -95,7 +99,5 @@ function FiltersComponent({ showTitle = true }) {
 		</div>
 	);
 }
-
-const Filters = memo(FiltersComponent);
 
 export default Filters;

--- a/excursiones/src/components/FiltersList/FilterList.js
+++ b/excursiones/src/components/FiltersList/FilterList.js
@@ -1,4 +1,4 @@
-import { memo } from "react";
+import React from "react";
 import { SkeletonTheme } from "react-loading-skeleton";
 import FiltersListCheckbox from "../FiltersListCheckbox/FiltersListCheckbox";
 import FilterPillSkeleton from "./FilterPillSkeleton";
@@ -9,16 +9,17 @@ import styles from "./FiltersList.module.css";
 
 /** @typedef {import("../../types").RootState} RootState */
 
-/** @typedef {object} FiltersListProps
+/** 
+ * @typedef {object} FiltersListProps
  * @property {string} filterName - El nombre de la categoría de filtro (ej. "area").
  */
 
 /**
  * Componente que muestra una lista de filtros para una categoría específica (ej. área, dificultad, tiempo).
  * @param {FiltersListProps} props - Las propiedades del componente.
- * @return {React.ReactElement} El componente de la lista de filtros.
+ * @returns {React.ReactElement} - El componente de la lista de filtros.
  */
-function FiltersListComponent({ filterName }) {
+function FiltersList({ filterName }) {
 	// Usamos el hook personalizado para obtener los datos y el estado de carga/error.
 	const { data: arrayFilters, isLoading, error } = useFilters(filterName);
 	// Usamos el hook personalizado para obtener los colores del esqueleto según el tema.
@@ -64,7 +65,5 @@ function FiltersListComponent({ filterName }) {
 		</ul>
 	);
 }
-
-const FiltersList = memo(FiltersListComponent);
 
 export default FiltersList;

--- a/excursiones/src/components/FiltersListCheckbox/FiltersListCheckbox.js
+++ b/excursiones/src/components/FiltersListCheckbox/FiltersListCheckbox.js
@@ -1,4 +1,4 @@
-import { memo, useId } from "react";
+import React, { useId } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { toggleFilter } from "../../slices/filterSlice";
 import cn from "classnames";
@@ -6,22 +6,26 @@ import styles from "./FiltersListCheckbox.module.css";
 
 /** @typedef {import("../../types").RootState} RootState */
 
-/** @typedef {object} FiltersListCheckboxProps
+/**
+ * @typedef {object} FiltersListCheckboxProps - Props del componente FiltersListCheckbox.
  * @property {string} filterName - El nombre de la categoría de filtro (ej. "area").
  * @property {string} filter - El valor específico del filtro (ej. "Picos de Europa").
  */
 
 /**
  * Componente que renderiza una única opción de filtro como una "píldora" interactiva.
- * @param {FiltersListCheckboxProps} props
- * @returns {React.ReactElement}
+ * @param {FiltersListCheckboxProps} props - Propiedades del componente.
+ * @returns {React.ReactElement} - El componente de filtro individual.
  */
-function FiltersListCheckboxComponent({ filterName, filter }) {
+function FiltersListCheckbox({ filterName, filter }) {
 	const dispatch = useDispatch();
 
 	// Obtenemos los filtros seleccionados para esta categoría (ej. 'area') desde Redux
 	const selectedFilters = useSelector(
-		/** @param {RootState} state */
+		/**
+		 * @param {RootState} state - El estado global de Redux.
+		 * @returns {string[]} - Array de filtros seleccionados para la categoría dada.
+		 */
 		(state) => state.filterReducer[filterName]
 	);
 
@@ -64,7 +68,5 @@ function FiltersListCheckboxComponent({ filterName, filter }) {
 		</>
 	);
 }
-
-const FiltersListCheckbox = memo(FiltersListCheckboxComponent);
 
 export default FiltersListCheckbox;

--- a/excursiones/src/components/Layout/Layout.js
+++ b/excursiones/src/components/Layout/Layout.js
@@ -1,9 +1,9 @@
-import React, { memo } from "react";
+import React from "react";
 import { Container, Row } from "react-bootstrap";
 import { Routes, Route, useLocation } from "react-router-dom";
 import NavigationBar from "../NavigationBar";
 import ExcursionsPage from "../ExcursionsPage";
-import OriginalFooter from "../Footer/Footer"; // Se renombra la importación original para que no haya conflictos
+import Footer from "../Footer"; // Se renombra la importación original para que no haya conflictos
 import ProtectedRoute from "../ProtectedRoute";
 import RegisterPageSkeleton from "../RegisterPage/RegisterPageSkeleton";
 import LoginPageSkeleton from "../LoginPage/LoginPageSkeleton";
@@ -23,9 +23,6 @@ import styles from "./Layout.module.css";
 const RegisterPage = lazyWithMinTime(() => import("../RegisterPage"));
 const LoginPage = lazyWithMinTime(() => import("../LoginPage"));
 const UserPage = lazyWithMinTime(() => import("../UserPage"));
-
-// Componente Footer memoizado para evitar re-renderizados innecesarios.
-const Footer = memo(OriginalFooter);
 
 /**
  * Componente principal de la aplicación. Gestiona el estado de las excursiones, la autenticación del usuario y la
@@ -58,7 +55,6 @@ const Layout = () => {
 				onFetchSuccess={handleExcursionsFetchSuccess}
 				onExcursionsFetchStart={handleExcursionsFetchStart}
 				onExcursionsFetchEnd={handleExcursionsFetchEnd}
-				isAuthCheckComplete={isAuthCheckComplete}
 				isOnExcursionsPage={isOnExcursionsPage}
 			/>
 			{/* Contenedor principal que alberga el contenido de la página */}

--- a/excursiones/src/components/Layout/index.js
+++ b/excursiones/src/components/Layout/index.js
@@ -1,3 +1,1 @@
-import Layout from "./Layout";
-
-export default Layout;
+export { default } from "./Layout";

--- a/excursiones/src/components/LoginForm/LoginForm.js
+++ b/excursiones/src/components/LoginForm/LoginForm.js
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useMemo } from "react";
+import React, { useState } from "react";
 import { Form } from "react-bootstrap";
 import {
 	validateMail,
@@ -21,16 +21,13 @@ export function LoginForm() {
 	const [mail, setMail] = useState("");
 	const [password, setPassword] = useState("");
 
-	const formValues = useMemo(() => ({ mail, password }), [mail, password]);
+	const formValues = { mail, password };
 
 	/**
 	 * Comprueba si el formulario es válido.
 	 * @returns {boolean} - `true` si el formulario es válido, `false` en caso contrario.
 	 */
-	const isFormValid = useCallback(
-		() => validateMail(mail) && isNotEmpty(password),
-		[mail, password]
-	);
+	const isFormValid = () => validateMail(mail) && isNotEmpty(password);
 
 	const { formState, formDispatch, handleSubmit } = useAuthFormHandler(
 		// El hook espera los argumentos para la API en el mismo orden.

--- a/excursiones/src/components/LoginPage/LoginPage.js
+++ b/excursiones/src/components/LoginPage/LoginPage.js
@@ -1,9 +1,14 @@
+import React from "react";
 import LoginForm from "../LoginForm";
 import FormPageLayout from "../FormPageLayout/FormPageLayout";
 import { ROUTES, LOGIN_PAGE_TEXT } from "../../constants";
 import "bootstrap/dist/css/bootstrap.css";
 
-// Componente que representa la página de inicio de sesión.
+/**
+ * Componente que representa la página de inicio de sesión.
+ * Utiliza el layout de formulario genérico y renderiza el formulario de login.
+ * @returns {React.ReactElement} - El componente de la página de inicio de sesión.
+ */
 function LoginPage() {
 	return (
 		<FormPageLayout

--- a/excursiones/src/components/NavigationBar/NavigationBar.js
+++ b/excursiones/src/components/NavigationBar/NavigationBar.js
@@ -3,9 +3,7 @@ import React, {
 	useLayoutEffect,
 	lazy,
 	Suspense,
-	memo,
 	useRef,
-	useCallback,
 } from "react";
 import { Container, Navbar, Offcanvas } from "react-bootstrap";
 import { useSelector } from "react-redux";
@@ -53,7 +51,7 @@ const getInitialAuthState = () => {
  * @param {NavigationBarProps} props - Las propiedades del componente.
  * @returns {React.ReactElement} - El componente de la barra de navegación.
  */
-function NavigationBarComponent({
+function NavigationBar({
 	onFetchSuccess,
 	onExcursionsFetchStart,
 	onExcursionsFetchEnd,
@@ -104,7 +102,7 @@ function NavigationBarComponent({
 		// El ResizeObserver es la forma moderna y eficiente de reaccionar a cambios de tamaño.
 		const observer = new ResizeObserver(() => {
 			// Si la altura de la barra de navegación cambia se vuelve a ejecutar la función updateHeight.
-			window.requestAnimationFrame(updateHeight);
+			globalThis.requestAnimationFrame(updateHeight);
 		});
 
 		updateHeight(); // Medimos la altura inicial
@@ -119,13 +117,13 @@ function NavigationBarComponent({
 	 * Cierra el menú lateral (Offcanvas).
 	 * @type {() => void}
 	 */
-	const handleCloseMenu = useCallback(() => setShowMenu(false), []);
+	const handleCloseMenu = () => setShowMenu(false);
 
 	/**
 	 * Abre el menú lateral (Offcanvas).
 	 * @type {() => void}
 	 */
-	const handleShowMenu = useCallback(() => setShowMenu(true), []);
+	const handleShowMenu = () => setShowMenu(true);
 
 	/**
 	 * Renderiza los botones de usuario o invitado.
@@ -253,5 +251,4 @@ function NavigationBarComponent({
 	);
 }
 
-const NavigationBar = memo(NavigationBarComponent);
 export default NavigationBar;

--- a/excursiones/src/components/ProtectedRoute/ProtectedRoute.js
+++ b/excursiones/src/components/ProtectedRoute/ProtectedRoute.js
@@ -4,19 +4,23 @@ import { Navigate, useLocation } from "react-router-dom";
 
 /** @typedef {import("../../types").RootState} RootState */
 
-/** @typedef {object} ProtectedRouteProps
+/**
+ * @typedef {object} ProtectedRouteProps
  * @property {React.ReactNode} children - El componente a renderizar si el usuario está autenticado.
  * @property {boolean} isAuthCheckComplete - Indica si la comprobación de autenticación inicial ha finalizado.
  */
 
 /**
  * Componente que protege rutas, redirigiendo a la página de login si el usuario no está autenticado.
- * @param {ProtectedRouteProps} props
- * @returns {React.ReactNode}
+ * @param {ProtectedRouteProps} props - Las propiedades del componente.
+ * @returns {React.ReactNode} - El componente protegido o una redirección a la página de login.
  */
 const ProtectedRoute = ({ children, isAuthCheckComplete }) => {
 	const { login: isLoggedIn } = useSelector(
-		/** @param {RootState} state */
+		/**
+		 * @param {RootState} state - El estado global de la aplicación.
+		 * @returns {import("../../types").LoginState} - El estado de login.
+		 */
 		(state) => state.loginReducer
 	);
 	// Se obtiene la ubicación actual para redirigir al usuario después de iniciar sesión.

--- a/excursiones/src/components/ProtectedRoute/index.js
+++ b/excursiones/src/components/ProtectedRoute/index.js
@@ -1,3 +1,1 @@
-import ProtectedRoute from "./ProtectedRoute";
-
-export default ProtectedRoute;
+export { default } from "./ProtectedRoute";

--- a/excursiones/src/components/RegisterForm/RegisterForm.js
+++ b/excursiones/src/components/RegisterForm/RegisterForm.js
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useCallback } from "react";
+import React, { useState } from "react";
 import { Row, Col, Form } from "react-bootstrap";
 import ValidatedFormGroup from "../ValidatedFormGroup";
 import {
@@ -43,19 +43,15 @@ function RegisterForm() {
 		setValues((prev) => ({ ...prev, [field]: value }));
 	};
 
-	const authFormValues = useMemo(
-		() => ({
-			name: values.name,
-			surname: values.surname,
-			phone: values.phone,
-			mail: values.mail,
-			password: values.password,
-		}),
-		// Dependencias primitivas para asegurar que el objeto solo se recrea cuando un valor cambia.
-		[values.name, values.surname, values.phone, values.mail, values.password]
-	);
+	const authFormValues = {
+		name: values.name,
+		surname: values.surname,
+		phone: values.phone,
+		mail: values.mail,
+		password: values.password,
+	};
 
-	const isFormValid = useCallback(() => {
+	const isFormValid = () => {
 		return (
 			validateName(values.name) === true &&
 			validateSurname(values.surname) === true &&
@@ -64,7 +60,7 @@ function RegisterForm() {
 			validatePassword(values.password) === true &&
 			validateSamePassword(values.password, values.samePassword) === true
 		);
-	}, [values]);
+	};
 
 	const { formState, formDispatch, handleSubmit } = useAuthFormHandler(
 		// El hook espera los argumentos para la API en el mismo orden.
@@ -75,72 +71,67 @@ function RegisterForm() {
 	);
 
 	// Configuración de los campos del formulario para renderizarlos dinámicamente.
-	// Se usa useMemo para evitar que se recalcule en cada renderizado, optimizando el rendimiento.
-	// Solo se recalculará si `values.password` cambia, que es la única dependencia externa.
-	const formFieldsConfig = useMemo(
-		() => [
-			[
-				{
-					id: "formGridName",
-					name: "Nombre",
-					field: "name",
-					validationFunction: validateName,
-					autocomplete: "given-name",
-					errorMessage: "El nombre no puede estar vacío.",
-				},
-				{
-					id: "formGridSurname",
-					name: "Apellidos",
-					field: "surname",
-					validationFunction: validateSurname,
-					autocomplete: "family-name",
-					errorMessage: "Los apellidos no pueden estar vacíos.",
-				},
-			],
-			[
-				{
-					id: "formGridPhone",
-					name: "Teléfono",
-					field: "phone",
-					inputType: "tel",
-					validationFunction: validatePhone,
-					autocomplete: "tel",
-					errorMessage: "El formato del teléfono no es válido.",
-				},
-				{
-					id: "formGridEmail",
-					name: "Correo electrónico",
-					field: "mail",
-					inputType: "email",
-					validationFunction: validateMail,
-					autocomplete: "email",
-					errorMessage: "El formato del correo electrónico no es válido.",
-				},
-			],
-			[
-				{
-					id: "password",
-					name: "Contraseña",
-					field: "password",
-					inputType: "password",
-					validationFunction: validatePassword,
-					autocomplete: "new-password",
-					ariaDescribedBy: "password-requirements",
-				},
-				{
-					id: "confirm-password",
-					name: "Repite la contraseña",
-					field: "samePassword",
-					inputType: "password",
-					// La validación de este campo depende del valor de la contraseña, por eso se define aquí.
-					validationFunction: (value) =>
-						validateSamePassword(values.password, value),
-					autocomplete: "new-password",
-				},
-			],
+	const formFieldsConfig = [
+		[
+			{
+				id: "formGridName",
+				name: "Nombre",
+				field: "name",
+				validationFunction: validateName,
+				autocomplete: "given-name",
+				errorMessage: "El nombre no puede estar vacío.",
+			},
+			{
+				id: "formGridSurname",
+				name: "Apellidos",
+				field: "surname",
+				validationFunction: validateSurname,
+				autocomplete: "family-name",
+				errorMessage: "Los apellidos no pueden estar vacíos.",
+			},
 		],
-		[values.password]
-	);
+		[
+			{
+				id: "formGridPhone",
+				name: "Teléfono",
+				field: "phone",
+				inputType: "tel",
+				validationFunction: validatePhone,
+				autocomplete: "tel",
+				errorMessage: "El formato del teléfono no es válido.",
+			},
+			{
+				id: "formGridEmail",
+				name: "Correo electrónico",
+				field: "mail",
+				inputType: "email",
+				validationFunction: validateMail,
+				autocomplete: "email",
+				errorMessage: "El formato del correo electrónico no es válido.",
+			},
+		],
+		[
+			{
+				id: "password",
+				name: "Contraseña",
+				field: "password",
+				inputType: "password",
+				validationFunction: validatePassword,
+				autocomplete: "new-password",
+				ariaDescribedBy: "password-requirements",
+			},
+			{
+				id: "confirm-password",
+				name: "Repite la contraseña",
+				field: "samePassword",
+				inputType: "password",
+				// La validación de este campo depende del valor de la contraseña, por eso se define aquí.
+				validationFunction: (value) =>
+					validateSamePassword(values.password, value),
+				autocomplete: "new-password",
+			},
+		],
+	];
 
 	const isButtonDisabled = !isFormValid();
 

--- a/excursiones/src/components/RegisterForm/index.js
+++ b/excursiones/src/components/RegisterForm/index.js
@@ -1,3 +1,1 @@
-import RegisterForm from "./RegisterForm";
-
-export default RegisterForm;
+export { default } from "./RegisterForm";

--- a/excursiones/src/components/RegisterPage/RegisterPage.js
+++ b/excursiones/src/components/RegisterPage/RegisterPage.js
@@ -1,3 +1,4 @@
+import React from "react";
 import RegisterForm from "../RegisterForm";
 import FormPageLayout from "../FormPageLayout/FormPageLayout";
 import "bootstrap/dist/css/bootstrap.css";
@@ -6,6 +7,7 @@ import "bootstrap/dist/css/bootstrap.css";
  * Componente que representa la página de registro de usuarios.
  * Utiliza `FormPageLayout` para proporcionar un diseño consistente con otras páginas de formulario, y renderiza `RegisterForm`
  * dentro de este layout.
+ * @returns {React.ReactElement} El componente de la página de registro.
  */
 function RegisterPage() {
 	return (

--- a/excursiones/src/components/SearchBar/SearchBar.js
+++ b/excursiones/src/components/SearchBar/SearchBar.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useRef } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { useSelector, shallowEqual } from "react-redux";
 import { FiSearch, FiX } from "react-icons/fi";
 import cn from "classnames";
@@ -76,11 +76,9 @@ function SearchBar({
 	}, [searchValue]);
 
 	/**
-	 * Función memoizada con useCallback para realizar la petición de búsqueda de excursiones.
-	 * useCallback evita que esta función se recree en cada renderizado, optimizando el rendimiento.
-	 * Ahora solo se volverá a crear si alguna de sus dependencias (debouncedSearch, area, etc.) cambia.
+	 * Realiza la petición de búsqueda de excursiones. El compilador de React se encargará de memoizar esta función.
 	 */
-	const fetchData = useCallback(async () => {
+	const fetchData = async () => {
 		// Llama a la función onFetchStart si se proporcionó, para indicar que la carga de excursiones ha comenzado.
 		onFetchStart?.();
 		try {
@@ -129,21 +127,13 @@ function SearchBar({
 			// Pasamos el error amigable a la UI para que se muestre
 			onFetchEnd?.(userFriendlyError);
 		}
-	}, [
-		debouncedSearch,
-		area,
-		difficulty,
-		time,
-		onFetchSuccess,
-		onFetchStart,
-		onFetchEnd,
-	]);
+	};
 
 	// Este efecto se ejecuta cada vez que el término de búsqueda "debounced" o los filtros cambian.
 	// De esta forma, los filtros se aplican instantáneamente, mientras que la búsqueda por texto espera.
 	useEffect(() => {
 		fetchData();
-	}, [fetchData]);
+	}, [debouncedSearch, area, difficulty, time]);
 
 	return (
 		<form

--- a/excursiones/src/components/StyledNavLink/StyledNavLink.js
+++ b/excursiones/src/components/StyledNavLink/StyledNavLink.js
@@ -1,4 +1,4 @@
-import React, { memo } from "react";
+import React from "react";
 import { NavLink } from "react-router-dom";
 import { Nav } from "react-bootstrap";
 import styles from "./StyledNavLink.module.css";
@@ -17,7 +17,7 @@ import styles from "./StyledNavLink.module.css";
  * @param {StyledNavLinkProps} props - Las propiedades del componente.
  * @returns {React.ReactElement} - El componente de enlace de navegación estilizado.
  */
-function StyledNavLinkComponent({
+function StyledNavLink({
 	children,
 	className = "",
 	variant = "link",
@@ -35,7 +35,5 @@ function StyledNavLinkComponent({
 		</Nav.Link>
 	);
 }
-
-const StyledNavLink = memo(StyledNavLinkComponent);
 
 export default StyledNavLink;

--- a/excursiones/src/components/UserNav/UserNav.js
+++ b/excursiones/src/components/UserNav/UserNav.js
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React from "react";
 import { useDispatch } from "react-redux";
 import { useNavigate } from "react-router-dom";
 import StyledNavLink from "../StyledNavLink";
@@ -31,12 +31,12 @@ function UserNav(props) {
 	/**
 	 * Maneja el proceso de cierre de sesión del usuario.
 	 */
-	const handleLogout = useCallback(() => {
+	const handleLogout = () => {
 		onCloseMenu?.();
 		logoutUser();
 		dispatch(logout());
 		navigate(ROUTES.HOME);
-	}, [dispatch, navigate, onCloseMenu]);
+	};
 
 	return (
 		<>

--- a/excursiones/src/components/UserPage/UserPage.js
+++ b/excursiones/src/components/UserPage/UserPage.js
@@ -1,3 +1,4 @@
+import React from "react";
 import { Row, Col } from "react-bootstrap";
 import UserInfoForm from "../UserInfoForm";
 import "bootstrap/dist/css/bootstrap.css";
@@ -5,8 +6,10 @@ import styles from "./UserPage.module.css";
 
 /** @typedef {import('types.js').RootState} RootState */
 
-/** Componente que representa la página de perfil del usuario.
+/** 
+ * Componente que representa la página de perfil del usuario.
  *  La lógica de protección de esta ruta se maneja en el componente `ProtectedRoute`.
+ * @returns {React.ReactElement} - El componente de la página de usuario.
  */
 function UserPage() {
 	return (

--- a/excursiones/src/components/ValidatedFormGroup/ValidatedFormGroup.js
+++ b/excursiones/src/components/ValidatedFormGroup/ValidatedFormGroup.js
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import React, { useState } from "react";
 import { Form } from "react-bootstrap";
 import "bootstrap/dist/css/bootstrap.css";
 import styles from "./ValidatedFormGroup.module.css";
@@ -8,7 +8,7 @@ import styles from "./ValidatedFormGroup.module.css";
  * @param {object} props - Las propiedades del componente.
  * @param {string} props.id - ID único para el campo de formulario y la etiqueta.
  * @param {string} props.name - Texto para la etiqueta del campo.
- * @param {string} [props.inputType="text"] - Tipo de input (ej. "text", "email", "password").
+ * @param {string} [props.inputType] - Tipo de input (ej. "text", "email", "password"). El valor por defecto es "text".
  * @param {(value: string) => void} props.inputToChange - Función para actualizar el estado del valor del input en el componente padre.
  * @param {(value: string) => boolean | string} props.validationFunction - Función que valida el valor del input. Retorna `true` si es válido, o un `string` con el mensaje de error.
  * @param {string} props.value - El valor actual del campo de formulario.
@@ -16,6 +16,7 @@ import styles from "./ValidatedFormGroup.module.css";
  * @param {string} [props.errorMessage] - Mensaje de error específico. Si no se proporciona, se usa uno genérico.
  * @param {string} props.autocomplete - Valor para el atributo autocomplete del input.
  * @param {string} [props.ariaDescribedBy] - IDs adicionales para aria-describedby, separados por espacios.
+ * @returns {React.ReactElement} - El componente de grupo de formulario validado.
  */
 function ValidatedFormGroup(props) {
 	const {


### PR DESCRIPTION
1. Se añade configuración de Babel para React Compiler y se agrega el plugin 'babel-plugin-react-compiler' como dependencia de desarrollo. 
2. Eliminados los usos innecesarios de React.memo y useCallback/useMemo en múltiples componentes para simplificar el código y mejorar la legibilidad. 
3. Se actualizan las importaciones y exportaciones para reflejar estos cambios.