### PR TITLE
Refactor password validation & input feedback

### DIFF
--- a/excursiones/src/components/RegisterForm/PasswordRequirements.tsx
+++ b/excursiones/src/components/RegisterForm/PasswordRequirements.tsx
@@ -1,4 +1,7 @@
-import { PASSWORD_REQUIREMENTS } from "../../validation/validations";
+import {
+	PASSWORD_RULES,
+	MIN_PASSWORD_LENGTH,
+} from "../../validation/validations";
 import styles from "./RegisterForm.module.css";
 import { CheckIcon } from "../../ui/Icons";
 import cn from "classnames";
@@ -11,6 +14,28 @@ interface PasswordRequirementsProps {
 	readonly password?: string;
 }
 
+/**
+ * Definición de los requisitos de contraseña con su etiqueta y función de validación correspondiente.
+ */
+const REQUIREMENTS_DATA = [
+	{
+		label: `${MIN_PASSWORD_LENGTH} caracteres`,
+		isValid: PASSWORD_RULES.hasMinLength,
+	},
+	{
+		label: "una letra",
+		isValid: PASSWORD_RULES.hasLetter,
+	},
+	{
+		label: "un número",
+		isValid: PASSWORD_RULES.hasNumber,
+	},
+	{
+		label: "un carácter especial (ej: @$!%*?&.,_-)",
+		isValid: PASSWORD_RULES.hasSpecialChar,
+	},
+];
+
 export function PasswordRequirements({
 	password = "",
 }: PasswordRequirementsProps) {
@@ -18,12 +43,15 @@ export function PasswordRequirements({
 		<div id="password-requirements" className={`${styles.infoMessage} mb-3`}>
 			<p className="mb-1">Tu contraseña debe tener al menos:</p>
 			<ul className="mb-0">
-				{PASSWORD_REQUIREMENTS.map((req) => {
+				{/* Recorremos cada requisito y verificamos si se cumple con la contraseña actual. 
+				Aplicamos estilos condicionales para indicar visualmente el estado de cada requisito. */}
+				{REQUIREMENTS_DATA.map((req) => {
 					const isMet = req.isValid(password);
 
 					return (
 						<li
 							key={req.label}
+							/* Si el requisito se cumple, aplicamos el estilo que lo resalta. */
 							className={cn({ [styles.requirementMet]: isMet })}
 						>
 							<span className="visually-hidden">
@@ -31,8 +59,9 @@ export function PasswordRequirements({
 							</span>
 							<div className={styles.requirementIcon}>
 								{isMet ? (
-									/* Solo animamos el CheckIcon cuando aparece usando la key */
 									<CheckIcon
+										/* La key es necesaria para que React lo trate como un elemento nuevo cuando aparece
+										lo que dispara la animación CSS. */
 										key="check"
 										size={14}
 										aria-hidden="true"

--- a/excursiones/src/components/RegisterForm/useRegisterForm.ts
+++ b/excursiones/src/components/RegisterForm/useRegisterForm.ts
@@ -87,7 +87,7 @@ export function useRegisterForm() {
 		ROUTES.HOME,
 	);
 
-	// Se define la estrcutura visual del formulario.
+	// Se define la estructura visual del formulario.
 	const formFieldsConfig: FormFieldConfig<RegisterFormValues>[][] = [
 		[
 			{
@@ -146,6 +146,7 @@ export function useRegisterForm() {
 				validationFunction: (val: string) =>
 					validateSamePassword(values.password, val),
 				autocomplete: "new-password",
+				errorMessage: "Las contraseñas no coinciden.",
 			},
 		],
 	];

--- a/excursiones/src/components/RegisterPage/RegisterPageSkeleton.tsx
+++ b/excursiones/src/components/RegisterPage/RegisterPageSkeleton.tsx
@@ -4,7 +4,7 @@ import { useSkeletonTheme } from "../../hooks/useSkeletonTheme";
 import Skeleton, { SkeletonTheme } from "react-loading-skeleton";
 import "react-loading-skeleton/dist/skeleton.css";
 import registerFormStyles from "../RegisterForm/RegisterForm.module.css";
-import { PASSWORD_REQUIREMENTS } from "../../validation/validations";
+import { PASSWORD_RULES } from "../../validation/validations";
 
 /**
  * Configuración para las filas del esqueleto del formulario. Cada sub-array representa una fila
@@ -65,11 +65,8 @@ function RegisterPageSkeleton() {
 							<Skeleton width="70%" />
 						</p>
 						<ul className="mb-0 list-unstyled" aria-hidden="true">
-							{PASSWORD_REQUIREMENTS.map((req, index) => (
-								<li
-									key={req.label}
-									className="d-flex align-items-center gap-2 mb-1"
-								>
+							{Object.keys(PASSWORD_RULES).map((key, index) => (
+								<li key={key} className="d-flex align-items-center gap-2 mb-1">
 									<div className={registerFormStyles.requirementIcon}>
 										<Skeleton
 											circle

--- a/excursiones/src/ui/ValidatedInput/ValidatedInput.tsx
+++ b/excursiones/src/ui/ValidatedInput/ValidatedInput.tsx
@@ -3,6 +3,7 @@ import Form from "react-bootstrap/Form";
 import InputGroup from "react-bootstrap/InputGroup";
 import Button from "react-bootstrap/Button";
 import "bootstrap/dist/css/bootstrap.css";
+import cn from "classnames";
 import { EyeIcon, EyeOffIcon, TriangleAlertIcon } from "../Icons";
 import styles from "./ValidatedInput.module.css";
 
@@ -46,31 +47,29 @@ const ValidatedInput = forwardRef<HTMLInputElement, ValidatedInputProps>(
 			autocomplete,
 			ariaDescribedBy,
 		} = props;
-		// Estado para almacenar el mensaje de error de validación. `null` si es válido.
-		const [validationError, setValidationError] = useState<string | null>(null);
+
+		// Estado para saber si el usuario ha interactuado con el campo.
+		// Esto evita mostrar errores antes de que el usuario empiece a escribir.
+		const [touched, setTouched] = useState(false);
+
 		// Estado para controlar la visibilidad de la contraseña
 		const [showPassword, setShowPassword] = useState(false);
+
 		// ID único para el mensaje de error, para asociarlo con el input.
 		const errorId = `${id}-error`;
 
-		// Function that receives the information and updates it
+		/** Maneja el cambio en el input y marca el campo como tocado. */
 		const nameChange = (event: ChangeEvent<HTMLInputElement>) => {
-			const { value: newValue } = event.target;
-			inputToChange(newValue);
-			const validationResult = validationFunction(newValue);
-			// Si el resultado es `true`, la validación es correcta (sin error -> null).
-			// Si es un `string`, es el mensaje de error.
-			// Si es `false`, la validación falla, pero no hay mensaje específico,
-			// así que usamos un string vacío para indicar el error y mostrar el mensaje genérico.
-			setValidationError(
-				validationResult === true ? null : validationResult || "",
-			);
+			inputToChange(event.target.value);
+			if (!touched) setTouched(true);
 		};
 
-		// Combina los IDs externos con el ID del error interno si es visible.
-		const isInvalid = message && validationError !== null;
-		// Solo mostramos el mensaje si el campo es inválido Y tenemos un texto que mostrar.
-		const showErrorMessage = isInvalid && !!(validationError || errorMessage);
+		// Lógica derivada: La validez se calcula en cada render (optimizado por React Compiler).
+		const isValid = validationFunction(value) === true;
+		// Mostramos error solo si: el componente debe mostrar mensajes, ha sido tocado y no es válido.
+		const isInvalid = message && touched && !isValid;
+		const showErrorMessage = isInvalid && !!errorMessage;
+
 		const describedBy = [ariaDescribedBy, isInvalid ? errorId : null]
 			.filter(Boolean)
 			.join(" ");
@@ -83,21 +82,46 @@ const ValidatedInput = forwardRef<HTMLInputElement, ValidatedInputProps>(
 			setShowPassword((prev) => !prev);
 		};
 
+		// Elementos comunes para evitar redundancia y cumplir con el principio DRY.
+		const controlElement = (
+			<Form.Control
+				ref={ref}
+				type={currentType}
+				onChange={nameChange}
+				name={name}
+				value={value}
+				autoComplete={autocomplete}
+				isInvalid={isInvalid}
+				aria-describedby={describedBy || undefined}
+			/>
+		);
+
+		const feedbackElement = (
+			<Form.Control.Feedback
+				type="invalid"
+				id={errorId}
+				className={cn(
+					styles.errorContainer,
+					{ [styles.visible]: showErrorMessage },
+					"text-danger fw-bold",
+				)}
+				aria-live="polite"
+			>
+				{showErrorMessage && (
+					<div className={styles.errorContent}>
+						<TriangleAlertIcon size={18} className={styles.errorIcon} />
+						{errorMessage}
+					</div>
+				)}
+			</Form.Control.Feedback>
+		);
+
 		return (
-			<Form.Group className={`${styles.inputContainer} mb-3`} controlId={id}>
+			<Form.Group className={cn(styles.inputContainer, "mb-3")} controlId={id}>
 				<Form.Label>{name}</Form.Label>
 				{isPasswordType ? (
 					<InputGroup hasValidation>
-						<Form.Control
-							ref={ref}
-							type={currentType}
-							onChange={nameChange}
-							name={name}
-							value={value}
-							autoComplete={autocomplete}
-							isInvalid={isInvalid}
-							aria-describedby={describedBy || undefined}
-						/>
+						{controlElement}
 						<Button
 							variant="outline-secondary"
 							className={styles.passwordToggle}
@@ -109,49 +133,13 @@ const ValidatedInput = forwardRef<HTMLInputElement, ValidatedInputProps>(
 						>
 							{showPassword ? <EyeOffIcon size={20} /> : <EyeIcon size={20} />}
 						</Button>
-						{/* Feedback debe ir dentro del InputGroup cuando se usa hasValidation */}
-						<Form.Control.Feedback
-							type="invalid"
-							id={errorId}
-							className={`${styles.errorContainer} ${showErrorMessage ? styles.visible : ""} text-danger fw-bold`}
-							aria-live="polite"
-						>
-							{showErrorMessage && (
-								<div className={styles.errorContent}>
-									<TriangleAlertIcon size={18} className={styles.errorIcon} />
-									{validationError || errorMessage}
-								</div>
-							)}
-						</Form.Control.Feedback>
+						{feedbackElement}
 					</InputGroup>
 				) : (
-					<Form.Control
-						ref={ref}
-						type={inputType}
-						onChange={nameChange}
-						name={name}
-						value={value}
-						autoComplete={autocomplete}
-						isInvalid={isInvalid}
-						aria-describedby={describedBy || undefined}
-					/>
-				)}
-
-				{/* Renderizamos el feedback fuera si NO es password */}
-				{!isPasswordType && (
-					<Form.Control.Feedback
-						type="invalid"
-						id={errorId}
-						className={`${styles.errorContainer} ${showErrorMessage ? styles.visible : ""} text-danger fw-bold`}
-						aria-live="polite"
-					>
-						{showErrorMessage && (
-							<div className={styles.errorContent}>
-								<TriangleAlertIcon size={18} className={styles.errorIcon} />
-								{validationError || errorMessage}
-							</div>
-						)}
-					</Form.Control.Feedback>
+					<>
+						{controlElement}
+						{feedbackElement}
+					</>
 				)}
 			</Form.Group>
 		);

--- a/excursiones/src/ui/ValidatedInput/ValidatedInput.tsx
+++ b/excursiones/src/ui/ValidatedInput/ValidatedInput.tsx
@@ -64,6 +64,11 @@ const ValidatedInput = forwardRef<HTMLInputElement, ValidatedInputProps>(
 			if (!touched) setTouched(true);
 		};
 
+		/** Marca el campo como tocado cuando pierde el foco, para mostrar errores de validación. */
+		const handleBlur = () => {
+			if (!touched) setTouched(true);
+		};
+
 		// Lógica derivada: La validez se calcula en cada render (optimizado por React Compiler).
 		const isValid = validationFunction(value) === true;
 		// Mostramos error solo si: el componente debe mostrar mensajes, ha sido tocado y no es válido.
@@ -88,6 +93,7 @@ const ValidatedInput = forwardRef<HTMLInputElement, ValidatedInputProps>(
 				ref={ref}
 				type={currentType}
 				onChange={nameChange}
+				onBlur={handleBlur}
 				name={name}
 				value={value}
 				autoComplete={autocomplete}

--- a/excursiones/src/validation/validations.ts
+++ b/excursiones/src/validation/validations.ts
@@ -57,59 +57,40 @@ export function validateMail(mail: string): boolean {
 }
 
 /**
- * Lista de requisitos para validar la fortaleza de una contraseña.
- * Cada requisito tiene un mensaje de error y una función que verifica si la contraseña cumple con ese requisito.
+ * Longitud mínima permitida para las contraseñas.
+ * Se exporta para que la UI pueda mostrar este valor dinámicamente.
  */
-export const PASSWORD_REQUIREMENTS: {
-	label: string;
-	isValid: (password: string) => boolean;
-}[] = [
-	{
-		label: "8 caracteres",
-		isValid: (password) => password.length >= 8,
-	},
-	{
-		label: "una letra",
-		isValid: (password) => /[A-Za-z]/.test(password),
-	},
-	{
-		label: "un número",
-		isValid: (password) => /\d/.test(password),
-	},
-	{
-		label: "un carácter especial (ej: @$!%*?&.,_-)",
-		isValid: (password) => /[@$!%*?&.,_-]/.test(password),
-	},
-];
+export const MIN_PASSWORD_LENGTH = 8;
+
+/**
+ * Reglas individuales para la validación de contraseñas.
+ */
+export const PASSWORD_RULES = {
+	hasMinLength: (password: string) => password.length >= MIN_PASSWORD_LENGTH,
+	hasLetter: (password: string) => /[A-Za-z]/.test(password),
+	hasNumber: (password: string) => /\d/.test(password),
+	hasSpecialChar: (password: string) => /[@$!%*?&.,_-]/.test(password),
+};
 
 /**
  * Valida la fortaleza de una contraseña.
- * Retorna `true` si es válida, o un `string` con el error específico si no lo es.
+ * Retorna `true` si cumple con todos los requisitos de seguridad establecidos.
  * @param password - La contraseña a validar.
- * @returns - Retorna `true` si la contraseña es válida, o un mensaje de error.
+ * @returns - Booleano que indica si la contraseña es válida.
  */
-export function validatePassword(password: string): true | string {
-	// Itera sobre los requisitos y retorna el primer mensaje de error que encuentre.
-	for (const requirement of PASSWORD_REQUIREMENTS) {
-		if (!requirement.isValid(password)) {
-			return `Debe tener al menos ${requirement.label}.`;
-		}
-	}
-	return true;
+export function validatePassword(password: string): boolean {
+	return Object.values(PASSWORD_RULES).every((rule) => rule(password));
 }
 
 /**
  * Comprueba que dos contraseñas coincidan.
  * @param password - La contraseña original.
  * @param samePassword - La contraseña de confirmación.
- * @returns - Retorna `true` si ambas contraseñas son iguales, o un `string` con el mensaje de error.
+ * @returns - Booleano que indica si ambas contraseñas son iguales.
  */
 export function validateSamePassword(
 	password: string,
 	samePassword: string,
-): true | string {
-	if (password !== samePassword) {
-		return "Las contraseñas no coinciden.";
-	}
-	return true;
+): boolean {
+	return password === samePassword;
 }


### PR DESCRIPTION
1. Replace PASSWORD_REQUIREMENTS with MIN_PASSWORD_LENGTH and PASSWORD_RULES (individual rule functions) and change validatePassword/validateSamePassword to return booleans. 
2. Update components to use the new API: PasswordRequirements now builds its list from PASSWORD_RULES and MIN_PASSWORD_LENGTH (adds comments and a key on CheckIcon for animation), RegisterPageSkeleton renders skeleton items from PASSWORD_RULES keys, and useRegisterForm adds an errorMessage for confirm-password. 
3. Refactor ValidatedInput to track touched state (avoid showing errors before user interaction), compute validity from validationFunction, consolidate control/feedback elements (DRY), use classnames, and improve accessibility. 
4. Small typo/comment fixes included.