### PR TITLE
refactor(SearchBar): extract logic to hook

### DIFF
--- a/excursiones/src/components/SearchBar/SearchBar.module.css
+++ b/excursiones/src/components/SearchBar/SearchBar.module.css
@@ -1,3 +1,11 @@
+.wrapper {
+	display: flex;
+	flex-direction: column;
+	gap: 1rem; /* Espaciado orgánico entre buscador y posibles errores (Regla 5) */
+	width: 100%;
+	margin-bottom: 1.5rem;
+}
+
 .searchContainer {
 	position: relative;
 	width: 100%;
@@ -53,10 +61,10 @@
 
 /* Aseguramos que el input no tenga estilos de foco propios, ya que los maneja el contenedor */
 .searchInput:focus,
-.searchInput:focus-visible {
+.searchContainer .searchInput:focus-visible {
 	background-color: transparent;
-	box-shadow: none !important; /* Importante para anular el estilo global :focus-visible de Themes.css */
-	outline: none; /* Doble seguridad para evitar el borde cuadrado */
+	box-shadow: none; /* Elevamos especificidad con el padre para evitar !important */
+	outline: none;
 	color: var(--color-text-base);
 }
 
@@ -98,4 +106,19 @@
 
 .clearButton:focus-visible {
 	outline: none;
+}
+
+.errorWrapper {
+	animation: fadeInSlide 0.3s ease-out; /* Micro-interacción premium */
+}
+
+@keyframes fadeInSlide {
+	from {
+		opacity: 0;
+		transform: translateY(-10px);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
 }

--- a/excursiones/src/components/SearchBar/SearchBar.module.css
+++ b/excursiones/src/components/SearchBar/SearchBar.module.css
@@ -1,9 +1,9 @@
 .wrapper {
 	display: flex;
 	flex-direction: column;
-	gap: 1rem; /* Espaciado orgánico entre buscador y posibles errores (Regla 5) */
+	gap: var(--space-4); /* Espaciado orgánico entre buscador y posibles errores (Regla 5) */
 	width: 100%;
-	margin-bottom: 1.5rem;
+	margin-bottom: var(--space-6);
 }
 
 .searchContainer {

--- a/excursiones/src/components/SearchBar/SearchBar.tsx
+++ b/excursiones/src/components/SearchBar/SearchBar.tsx
@@ -2,7 +2,7 @@ import React, { useRef } from "react";
 import { Excursion } from "../../types";
 import { SearchIcon, XIcon } from "../../ui/Icons";
 import { FeedbackAlert } from "../../ui/FeedbackAlert/FeedbackAlert";
-import { useSearchBarLogic } from "./useSearchBarLogic";
+import { useSearchBarLogic, SearchError } from "./useSearchBarLogic";
 import styles from "./SearchBar.module.css";
 
 // Propiedades del componente.
@@ -14,9 +14,7 @@ interface SearchBarProps {
 	readonly onExcursionsFetchStart: () => void;
 
 	// Función que se llama al finalizar la búsqueda de excursiones, recibiendo un error si ocurrió alguno.
-	readonly onExcursionsFetchEnd: (
-		error: (Error & { secondaryMessage?: string }) | null,
-	) => void;
+	readonly onExcursionsFetchEnd: (error: SearchError | null) => void;
 
 	// Identificador único para el input de búsqueda, utilizado para accesibilidad.
 	readonly id: string;

--- a/excursiones/src/components/SearchBar/SearchBar.tsx
+++ b/excursiones/src/components/SearchBar/SearchBar.tsx
@@ -1,45 +1,31 @@
-import React, { useState, useEffect, useRef } from "react";
-import { useSelector, shallowEqual } from "react-redux";
-import { searchExcursions } from "../../services/excursionService";
+import React, { useRef } from "react";
 import { Excursion } from "../../types";
-import { RootState } from "../../store/store";
 import { SearchIcon, XIcon } from "../../ui/Icons";
+import { FeedbackAlert } from "../../ui/FeedbackAlert/FeedbackAlert";
+import { useSearchBarLogic } from "./useSearchBarLogic";
 import styles from "./SearchBar.module.css";
 
-// Constante para el tiempo de retraso del debounce
-const DEBOUNCE_DELAY_MS = 500;
-
-// Define las propiedades que acepta el componente SearchBar.
+// Propiedades del componente.
 interface SearchBarProps {
+	// Función que se llama cuando la búsqueda se realiza con éxito, recibiendo las excursiones encontradas.
 	readonly onFetchSuccess: (excursions: readonly Excursion[]) => void;
+
+	// Función que se llama al iniciar la búsqueda de excursiones, útil para mostrar un indicador de carga.
 	readonly onExcursionsFetchStart: () => void;
+
+	// Función que se llama al finalizar la búsqueda de excursiones, recibiendo un error si ocurrió alguno.
 	readonly onExcursionsFetchEnd: (
 		error: (Error & { secondaryMessage?: string }) | null,
 	) => void;
+
+	// Identificador único para el input de búsqueda, utilizado para accesibilidad.
 	readonly id: string;
+
+	// Valor actual del input de búsqueda, controlado desde el componente padre.
 	readonly searchValue: string;
+
+	// Función que se llama cuando el valor del input de búsqueda cambia, permitiendo actualizar el estado en el componente padre.
 	readonly onSearchChange: (value: string) => void;
-}
-
-/**
- * Genera un error amigable para el usuario basado en el error técnico capturado.
- */
-function createFriendlyError(
-	error: unknown,
-): Error & { secondaryMessage?: string } {
-	let userFriendlyError: Error & { secondaryMessage?: string };
-
-	if (error instanceof TypeError && error.message === "Failed to fetch") {
-		userFriendlyError = new Error("Error de conexión");
-		userFriendlyError.secondaryMessage =
-			"No se pudo conectar con el servidor. Por favor, revisa tu conexión a internet e inténtalo de nuevo.";
-	} else {
-		userFriendlyError = new Error("No se han podido cargar las excursiones.");
-		userFriendlyError.secondaryMessage =
-			"Por favor, inténtalo de nuevo más tarde.";
-	}
-
-	return userFriendlyError;
 }
 
 /**
@@ -53,110 +39,90 @@ export function SearchBar({
 	searchValue,
 	onSearchChange,
 }: SearchBarProps) {
-	const [debouncedSearch, setDebouncedSearch] = useState(searchValue);
+	// Referencia al input de búsqueda para manejar el foco y otras interacciones. Se utiliza para darle el foco
+	// al usuario después de limpiar la búsqueda.
 	const searchInputRef = useRef<HTMLInputElement>(null);
 
-	const { area, difficulty, time } = useSelector(
-		(state: RootState) => state.filterReducer,
-		shallowEqual,
-	);
+	// Extraemos la lógica de negocio al hook personalizado.
+	const { error, clearError } = useSearchBarLogic({
+		searchValue,
+		onFetchSuccess,
+		onExcursionsFetchStart,
+		onExcursionsFetchEnd,
+	});
 
 	/**
-	 * Maneja el evento `onChange` del input de búsqueda, actualizando el estado `search`.
+	 * Maneja el evento `onChange` del input de búsqueda, actualizando el estado `search`. Notifica al componente
+	 * padre cada vez que el usuario teclea algo en el input, permitiendo que la búsqueda se ejecute con el nuevo
+	 * valor.
 	 */
 	const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
 		onSearchChange(event.target.value);
 	};
 
 	/**
-	 * Limpia el contenido del input de búsqueda y da el foco al mismo.
+	 * Limpia el contenido del input de búsqueda y da el foco al input para que el usuario pueda volver a escribir
+	 * sin tener quedar clicks innecesarios.
 	 */
 	const handleClearSearch = () => {
 		onSearchChange("");
 		searchInputRef.current?.focus();
 	};
 
-	// Efecto para aplicar el "debounce" al término de búsqueda.
-	// Solo actualiza `debouncedSearch` cuando el usuario deja de teclear por 500ms.
-	useEffect(() => {
-		const timerId = setTimeout(() => {
-			setDebouncedSearch(searchValue);
-		}, DEBOUNCE_DELAY_MS);
-
-		return () => clearTimeout(timerId);
-	}, [searchValue]);
-
-	// Usamos refs para almacenar las props de función y evitar que el useEffect se vuelva a ejecutar innecesariamente.
-	const onFetchSuccessRef = useRef(onFetchSuccess);
-	const onExcursionsFetchStartRef = useRef(onExcursionsFetchStart);
-	const onExcursionsFetchEndRef = useRef(onExcursionsFetchEnd);
-
-	// Mantenemos las refs actualizadas si las props cambian.
-	useEffect(() => {
-		onFetchSuccessRef.current = onFetchSuccess;
-		onExcursionsFetchStartRef.current = onExcursionsFetchStart;
-		onExcursionsFetchEndRef.current = onExcursionsFetchEnd;
-	}, [onFetchSuccess, onExcursionsFetchStart, onExcursionsFetchEnd]);
-
-	// Este efecto se ejecuta cada vez que el término de búsqueda "debounced" o los filtros cambian.
-	// De esta forma, los filtros se aplican instantáneamente, mientras que la búsqueda por texto espera.
-	useEffect(() => {
-		const fetchData = async () => {
-			onExcursionsFetchStartRef.current();
-			try {
-				const data = await searchExcursions({
-					debouncedSearch,
-					area,
-					difficulty,
-					time,
-				});
-				onFetchSuccessRef.current(data);
-				onExcursionsFetchEndRef.current(null);
-			} catch (error) {
-				console.error("Error técnico al buscar excursiones:", error);
-				onFetchSuccessRef.current([]);
-
-				onExcursionsFetchEndRef.current(createFriendlyError(error));
-			}
-		};
-
-		fetchData();
-	}, [debouncedSearch, area, difficulty, time]);
-
-	/** Evita el envío del formulario por defecto. */
+	/**
+	 * Evita que el navegador recargue la página si el usuario pulsa la tecla Enter.
+	 */
 	const handleSubmit = (e: React.FormEvent) => {
 		e.preventDefault();
 	};
 
 	return (
-		<form
-			role="search"
-			className={styles.searchContainer}
-			onSubmit={handleSubmit}
-		>
-			<SearchIcon className={styles.searchIcon} aria-hidden="true" />
-			<label htmlFor={id} className="visually-hidden">
-				Buscar excursiones por nombre
-			</label>
-			<input
-				ref={searchInputRef}
-				id={id}
-				className={styles.searchInput}
-				type="search"
-				placeholder="¿A dónde quieres ir?"
-				value={searchValue}
-				onChange={handleSearchChange}
-			/>
-			{searchValue && (
-				<button
-					type="button"
-					className={styles.clearButton}
-					onClick={handleClearSearch}
-					aria-label="Limpiar búsqueda"
-				>
-					<XIcon className={styles.clearIcon} aria-hidden="true" />
-				</button>
+		/* Contenedor principal de la barra de búsqueda, que incluye el formulario y el área de mensajes de error. */
+		<div className={styles.wrapper}>
+			<form
+				// Ayuda a los usuarios de tecnologías asistivas a identificar esta sección como un área de búsqueda.
+				role="search"
+				className={styles.searchContainer}
+				onSubmit={handleSubmit}
+			>
+				<SearchIcon className={styles.searchIcon} aria-hidden="true" />
+				<label htmlFor={id} className="visually-hidden">
+					Buscar excursiones por nombre
+				</label>
+				<input
+					ref={searchInputRef}
+					id={id}
+					className={styles.searchInput}
+					type="search"
+					placeholder="¿A dónde quieres ir?"
+					value={searchValue}
+					onChange={handleSearchChange}
+				/>
+				{/* Solo mostramos el botón de limpiar búsqueda si hay algo escrito en el input, para evitar 
+				confusión al usuario. */}
+				{searchValue && (
+					<button
+						type="button"
+						className={styles.clearButton}
+						onClick={handleClearSearch}
+						aria-label="Limpiar búsqueda"
+					>
+						<XIcon className={styles.clearIcon} aria-hidden="true" />
+					</button>
+				)}
+			</form>
+			{/* Si el hook detecta un error, mostramos un mensaje de error amigable para el usuario utilizando el 
+			componente FeedbackAlert. */}
+			{error && (
+				<div className={styles.errorWrapper}>
+					<FeedbackAlert
+						variant="danger"
+						title={error.message}
+						message={error.secondaryMessage || ""}
+						onClose={clearError}
+					/>
+				</div>
 			)}
-		</form>
+		</div>
 	);
 }

--- a/excursiones/src/components/SearchBar/useSearchBarLogic.ts
+++ b/excursiones/src/components/SearchBar/useSearchBarLogic.ts
@@ -1,0 +1,123 @@
+import { useState, useEffect, useRef } from "react";
+import { useSelector, shallowEqual } from "react-redux";
+import { searchExcursions } from "../../services/excursionService";
+import { RootState } from "../../store/store";
+import { Excursion } from "../../types";
+
+const DEBOUNCE_DELAY_MS = 500;
+
+// Constantes para mensajes de error (Regla 2: Sustituir literales)
+const ERR_CONNECTION_TITLE = "Error de conexión";
+const ERR_CONNECTION_MSG =
+	"No se pudo conectar con el servidor. Revisa tu conexión.";
+const ERR_FETCH_TITLE = "Error al buscar";
+const ERR_FETCH_MSG =
+	"No se han podido cargar las excursiones. Inténtalo de nuevo más tarde.";
+/** Mensaje nativo que devuelven los navegadores ante errores de red. */
+const MENSAJE_ERROR_RED_NATIVO = "Failed to fetch";
+
+interface UseSearchBarLogicProps {
+	searchValue: string;
+	onFetchSuccess: (excursions: readonly Excursion[]) => void;
+	onExcursionsFetchStart: () => void;
+	onExcursionsFetchEnd: (
+		error: (Error & { secondaryMessage?: string }) | null,
+	) => void;
+}
+
+/**
+ * Genera un error amigable para el usuario basado en el error técnico capturado.
+ */
+function createFriendlyError(
+	error: unknown,
+): Error & { secondaryMessage?: string } {
+	if (
+		error instanceof TypeError &&
+		error.message === MENSAJE_ERROR_RED_NATIVO
+	) {
+		const err: Error & { secondaryMessage?: string } = new Error(
+			ERR_CONNECTION_TITLE,
+		);
+		err.secondaryMessage = ERR_CONNECTION_MSG;
+		return err;
+	}
+	const err: Error & { secondaryMessage?: string } = new Error(ERR_FETCH_TITLE);
+	err.secondaryMessage = ERR_FETCH_MSG;
+	return err;
+}
+
+/**
+ * Hook que encapsula la lógica de búsqueda, debounce y sincronización con el servicio de excursiones.
+ */
+export function useSearchBarLogic({
+	searchValue,
+	onFetchSuccess,
+	onExcursionsFetchStart,
+	onExcursionsFetchEnd,
+}: UseSearchBarLogicProps) {
+	const [debouncedSearch, setDebouncedSearch] = useState(searchValue);
+	const [error, setError] = useState<
+		(Error & { secondaryMessage?: string }) | null
+	>(null);
+
+	const { area, difficulty, time } = useSelector(
+		(state: RootState) => state.filterReducer,
+		shallowEqual,
+	);
+
+	// Refs para estabilidad referencial de callbacks de props (Regla 1 de GEMINI.md)
+	const onFetchSuccessRef = useRef(onFetchSuccess);
+	const onExcursionsFetchStartRef = useRef(onExcursionsFetchStart);
+	const onExcursionsFetchEndRef = useRef(onExcursionsFetchEnd);
+
+	useEffect(() => {
+		onFetchSuccessRef.current = onFetchSuccess;
+		onExcursionsFetchStartRef.current = onExcursionsFetchStart;
+		onExcursionsFetchEndRef.current = onExcursionsFetchEnd;
+	}, [onFetchSuccess, onExcursionsFetchStart, onExcursionsFetchEnd]);
+
+	// Manejo del Debounce
+	useEffect(() => {
+		const timerId = setTimeout(() => {
+			setDebouncedSearch(searchValue);
+		}, DEBOUNCE_DELAY_MS);
+
+		return () => clearTimeout(timerId);
+	}, [searchValue]);
+
+	// Petición de datos
+	useEffect(() => {
+		const fetchData = async () => {
+			onExcursionsFetchStartRef.current();
+			try {
+				const data = await searchExcursions({
+					debouncedSearch,
+					area,
+					difficulty,
+					time,
+				});
+				onFetchSuccessRef.current(data);
+				setError(null);
+				onExcursionsFetchEndRef.current(null);
+			} catch (err) {
+				console.error("Error técnico al buscar excursiones:", err);
+				const friendlyError = createFriendlyError(err);
+				onFetchSuccessRef.current([]);
+				setError(friendlyError);
+				onExcursionsFetchEndRef.current(friendlyError);
+			}
+		};
+
+		fetchData();
+	}, [debouncedSearch, area, difficulty, time]);
+
+	const clearError = () => {
+		setError(null);
+	};
+
+	return {
+		debouncedSearch,
+		error,
+		clearError,
+	};
+}

--- a/excursiones/src/components/SearchBar/useSearchBarLogic.ts
+++ b/excursiones/src/components/SearchBar/useSearchBarLogic.ts
@@ -13,35 +13,37 @@ const ERR_CONNECTION_MSG =
 const ERR_FETCH_TITLE = "Error al buscar";
 const ERR_FETCH_MSG =
 	"No se han podido cargar las excursiones. Inténtalo de nuevo más tarde.";
-/** Mensaje nativo que devuelven los navegadores ante errores de red. */
+/** Mensaje nativo que retornan los navegadores ante errores de red. */
 const MENSAJE_ERROR_RED_NATIVO = "Failed to fetch";
+
+/**
+ * Interfaz que extiende el Error estándar para incluir un mensaje secundario amigable.
+ * Sigue el principio de Single Source of Truth para la gestión de errores de búsqueda.
+ */
+export interface SearchError extends Error {
+	secondaryMessage?: string;
+}
 
 interface UseSearchBarLogicProps {
 	searchValue: string;
 	onFetchSuccess: (excursions: readonly Excursion[]) => void;
 	onExcursionsFetchStart: () => void;
-	onExcursionsFetchEnd: (
-		error: (Error & { secondaryMessage?: string }) | null,
-	) => void;
+	onExcursionsFetchEnd: (error: SearchError | null) => void;
 }
 
 /**
  * Genera un error amigable para el usuario basado en el error técnico capturado.
  */
-function createFriendlyError(
-	error: unknown,
-): Error & { secondaryMessage?: string } {
+function createFriendlyError(error: unknown): SearchError {
 	if (
 		error instanceof TypeError &&
 		error.message === MENSAJE_ERROR_RED_NATIVO
 	) {
-		const err: Error & { secondaryMessage?: string } = new Error(
-			ERR_CONNECTION_TITLE,
-		);
+		const err: SearchError = new Error(ERR_CONNECTION_TITLE);
 		err.secondaryMessage = ERR_CONNECTION_MSG;
 		return err;
 	}
-	const err: Error & { secondaryMessage?: string } = new Error(ERR_FETCH_TITLE);
+	const err: SearchError = new Error(ERR_FETCH_TITLE);
 	err.secondaryMessage = ERR_FETCH_MSG;
 	return err;
 }
@@ -56,9 +58,7 @@ export function useSearchBarLogic({
 	onExcursionsFetchEnd,
 }: UseSearchBarLogicProps) {
 	const [debouncedSearch, setDebouncedSearch] = useState(searchValue);
-	const [error, setError] = useState<
-		(Error & { secondaryMessage?: string }) | null
-	>(null);
+	const [error, setError] = useState<SearchError | null>(null);
 
 	const { area, difficulty, time } = useSelector(
 		(state: RootState) => state.filterReducer,
@@ -116,7 +116,6 @@ export function useSearchBarLogic({
 	};
 
 	return {
-		debouncedSearch,
 		error,
 		clearError,
 	};


### PR DESCRIPTION
1. Move search/debounce/fetch logic out of SearchBar into a new useSearchBarLogic hook and convert SearchBar into a presentational component. The hook encapsulates debounce, Redux filter selection, searchExcursions calls, friendly error mapping and lifecycle callbacks (onExcursionsFetchStart/onFetchSuccess/onExcursionsFetchEnd). SearchBar.tsx now uses the hook, renders FeedbackAlert for errors, simplifies event handlers and DOM structure (adds wrapper div) and accepts new fetch-related props. 
2. CSS tweaks in SearchBar.module.css add a wrapper layout, increase focus selector specificity, and add a fade-in animation for error messages.