### PR TITLE
refactor(ThemeToggleButton): update copy & styles

### DIFF
--- a/excursiones/src/components/AboutUs/AboutUs.module.css
+++ b/excursiones/src/components/AboutUs/AboutUs.module.css
@@ -41,7 +41,7 @@
 }
 
 .icon {
-	font-size: var(--font-size-xxl);
+	font-size: var(--font-size-display);
 	margin-bottom: var(--space-4);
 	color: var(--color-text-brand);
 }

--- a/excursiones/src/components/AboutUs/AboutUs.tsx
+++ b/excursiones/src/components/AboutUs/AboutUs.tsx
@@ -4,11 +4,11 @@ import styles from "./AboutUs.module.css";
 const CONTENT = {
 	eyebrow: "Nuestra Filosofía",
 	title: {
-		start: "Redescubriendo el placer de",
+		start: "Descubriendo el placer de",
 		highlight: "explorar.",
 	},
 	description:
-		"Para nosotros, la verdadera aventura no se mide en kilómetros, sino en la calma de un paisaje compartido y en las historias que nacen alrededor de un sendero. Nos une el respeto por el silencio de los bosques, la luz de la mañana y el compromiso de dejar una huella mínima en la tierra que tanto nos regala. Aquí no solo caminamos; aprendemos a mirar de nuevo.",
+		"Para nosotros, la verdadera aventura no se mide en kilómetros, sino en la calma de un paisaje compartido y en las historias que nacen alrededor de un sendero. Nos une el respeto por el silencio de los bosques, la luz de la mañana y el compromiso de dejar una huella mínima en la tierra que tanto nos regala.",
 };
 
 export function AboutUs() {

--- a/excursiones/src/components/Hero/Hero.tsx
+++ b/excursiones/src/components/Hero/Hero.tsx
@@ -10,7 +10,7 @@ import { ROUTES } from "../../constants";
 const HERO_CONTENT = {
 	title: "Respira, Camina, Conecta",
 	subtitle:
-		"Conecta con la naturaleza, explora paisajes inolvidables y comparte experiencias únicas con tus compañeros de viaje.",
+		"Explora paisajes inolvidables y comparte experiencias únicas con tus compañeros de viaje.",
 	cta: "Crea tu cuenta",
 };
 

--- a/excursiones/src/components/NavigationBar/NavigationBar.tsx
+++ b/excursiones/src/components/NavigationBar/NavigationBar.tsx
@@ -7,9 +7,8 @@ import { RootState } from "../../store/store";
 import Logo from "../Logo";
 import UserNavSkeleton from "../UserNav/UserNavSkeleton";
 import GuestNavSkeleton from "../GuestNav/GuestNavSkeleton";
-import ThemeToggleButton from "../ThemeToggleButton";
+import { ThemeToggleButton } from "../ThemeToggleButton";
 import styles from "./NavigationBar.module.css";
-import "../../css/Themes.css";
 import { ROUTES } from "../../constants";
 
 // Estos componentes se cargan de forma perezosa.

--- a/excursiones/src/components/ThemeToggleButton/ThemeToggleButton.module.css
+++ b/excursiones/src/components/ThemeToggleButton/ThemeToggleButton.module.css
@@ -36,7 +36,7 @@
 
 /* Para el foco con teclado, aplicamos la transformación y nuestro anillo de foco personalizado. */
 .themeToggleBtn:focus-visible {
-	box-shadow: 0 0 0 var(--space-1, 0.25rem) var(--focus-ring-color);
+	box-shadow: 0 0 0 var(--space-1) var(--focus-ring-color);
 	outline: none;
 }
 

--- a/excursiones/src/components/ThemeToggleButton/ThemeToggleButton.module.css
+++ b/excursiones/src/components/ThemeToggleButton/ThemeToggleButton.module.css
@@ -1,11 +1,10 @@
-/* Botón nativo para cambio de tema */
 .themeToggleBtn {
 	background-color: transparent;
 	color: var(--theme-toggle-btn-color);
-	border: 1px solid transparent; /* Reserva espacio para borde en focus */
-	width: 2.75rem;
-	height: 2.75rem; /* 44px */
-	border-radius: 50%;
+	border: 1px solid transparent;
+	width: 2.75rem; /* 44px - Touch target optimizado */
+	height: 2.75rem;
+	border-radius: var(--border-radius-full, 9999px);
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -13,15 +12,17 @@
 	cursor: pointer;
 	-webkit-tap-highlight-color: transparent; /* Evita el parpadeo gris al tocar en iOS */
 	/* Transición suave para movimiento y color de fondo */
-	transition: transform var(--transition-base);
+	transition:
+		transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1),
+		background-color 0.25s ease;
 }
 
 .themeIcon {
-	font-size: 1.25rem; /* Ligeramente más fino */
+	display: block;
 	color: var(--theme-toggle-btn-icon);
 }
 
-/* Para el estado hover, solo aplicamos la transformación. */
+/* Estado Hover: Elevación sutil para jerarquía visual */
 .themeToggleBtn:hover,
 .themeToggleBtn:focus-visible {
 	transform: translateY(-2px);
@@ -35,12 +36,13 @@
 
 /* Para el foco con teclado, aplicamos la transformación y nuestro anillo de foco personalizado. */
 .themeToggleBtn:focus-visible {
-	box-shadow: 0 0 0 0.25rem var(--focus-ring-color);
+	box-shadow: 0 0 0 var(--space-1, 0.25rem) var(--focus-ring-color);
 	outline: none;
 }
 
+/* Estado Active: Micro-interacción de "compresión" orgánica */
 .themeToggleBtn:active {
-	background-color: transparent;
+	background-color: var(--theme-toggle-btn-bg-hover);
 	border-color: transparent;
 	color: var(--theme-toggle-btn-color);
 	transform: translateY(0) scale(0.92);

--- a/excursiones/src/components/ThemeToggleButton/ThemeToggleButton.tsx
+++ b/excursiones/src/components/ThemeToggleButton/ThemeToggleButton.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import { useSelector, useDispatch, TypedUseSelectorHook } from "react-redux";
 import { toggleMode } from "../../slices/themeSlice";
 import { MoonIcon, SunIcon } from "../../ui/Icons";
@@ -6,29 +6,25 @@ import styles from "./ThemeToggleButton.module.css";
 import { RootState, AppDispatch } from "../../store/store"; // Asegúrate de que la ruta sea correcta
 
 /**
- * Props para el componente ThemeToggleButton.
+ * Prop del componente.
  */
 interface ThemeToggleButtonProps {
 	readonly className?: string; // Clases CSS adicionales para el botón.
-	readonly showText?: boolean; // Si es true, muestra el texto junto al icono.
 }
 
-// Asignamos el icono a una constante con el tipo React.ElementType
-// para asegurar a TypeScript que es un componente JSX válido.
-
 /**
- * Botón que permite al usuario cambiar entre el tema claro y oscuro.
+ * Custom hooks locales para mantener la consistencia con el Store de Redux.
  */
 const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;
 const useAppDispatch = () => useDispatch<AppDispatch>();
 
 /**
  * Componente ThemeToggleButton.
+ *
+ * Permite al usuario alternar entre modos de color (claro/oscuro).
+ * Implementa una técnica de bloqueo de transiciones para un cambio de tema instantáneo y fluido.
  */
-function ThemeToggleButton({
-	className = "",
-	showText = false,
-}: ThemeToggleButtonProps) {
+export function ThemeToggleButton({ className = "" }: ThemeToggleButtonProps) {
 	const mode = useAppSelector((state: RootState) => state.themeReducer.mode);
 	const dispatch = useAppDispatch();
 
@@ -41,11 +37,13 @@ function ThemeToggleButton({
 			// Se selecciona la etiqueta <html>
 			const root = document.documentElement;
 
-			// Añadimos clase temporal para bloquear transiciones de color
+			/**
+			 * Aplicamos la clase 'theme-toggling' para suspender las transiciones de color en el DOM.
+			 * Esto evita que el usuario vea un degradado extraño mientras las variables CSS se actualizan.
+			 */
 			root.classList.add("theme-toggling");
 
-			// Se asegura de que la etiqueta <html> no tiene las clases 'light' y 'dark' aplicadas antes que el código añada
-			// la correcta basada en 'mode'
+			// Limpieza y aplicación del nuevo modo
 			root.classList.remove("light", "dark");
 			// Añade la clase 'mode' ('light' o 'dark') a <html>
 			root.classList.add(mode);
@@ -54,13 +52,11 @@ function ThemeToggleButton({
 
 			/**
 			 * Forzamos un reflow para que el cambio de variables CSS se aplique instantáneamente.
-			 * Usamos getBoundingClientRect() porque, al ser una llamada a función, satisface las
-			 * reglas de linter de "expresiones no usadas" sin necesidad de crear variables.
 			 */
 			root.getBoundingClientRect();
 
 			// Eliminamos la clase en el siguiente ciclo para restaurar transiciones de hover
-			const timer = setTimeout(() => {
+			const timer = globalThis.setTimeout(() => {
 				root.classList.remove("theme-toggling");
 			}, 50);
 
@@ -77,28 +73,22 @@ function ThemeToggleButton({
 
 	const icon =
 		mode === "light" ? (
-			<MoonIcon className={styles.themeIcon} />
+			<MoonIcon size={20} className={styles.themeIcon} />
 		) : (
-			<SunIcon className={styles.themeIcon} />
+			<SunIcon size={20} className={styles.themeIcon} />
 		);
 
 	return (
 		<button
 			type="button"
-			className={`${styles.themeToggleBtn} ${className}`}
+			className={`${styles.themeToggleBtn} ${className}`.trim()}
 			onClick={toggleTheme}
+			aria-pressed={mode === "dark"}
 			aria-label={
 				mode === "light" ? "Activa el modo oscuro" : "Activa el modo claro"
 			}
 		>
 			{icon}
-			{showText && (
-				<span className="ms-2">
-					{mode === "light" ? "Modo oscuro" : "Modo claro"}
-				</span>
-			)}
 		</button>
 	);
 }
-
-export default ThemeToggleButton;

--- a/excursiones/src/components/ThemeToggleButton/index.ts
+++ b/excursiones/src/components/ThemeToggleButton/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./ThemeToggleButton";
+export { ThemeToggleButton } from "./ThemeToggleButton";

--- a/excursiones/src/css.d.ts
+++ b/excursiones/src/css.d.ts
@@ -1,7 +1,10 @@
 /**
  * Declaración de tipos para los módulos CSS.
- * Esto le dice a TypeScript cómo interpretar los archivos `.module.css`.
  */
+
+// Permite importaciones de archivos CSS globales como efectos secundarios.
+declare module "*.css";
+
 declare module "*.module.css" {
 	const classes: { readonly [key: string]: string };
 	export default classes;

--- a/testserver/data/excursionsData.ts
+++ b/testserver/data/excursionsData.ts
@@ -50,7 +50,7 @@ const excursions: Excursion[] = [
 	{
 		id: "1",
 		name: "Cangas de Onís",
-		description: `Camina sobre el susurro del río Sella. Un encuentro con la historia bajo la silueta del Puente Romano, donde la piedra antigua te invita a una pausa necesaria.`,
+		description: `Camina sobre el susurro del río Sella. Un encuentro con la historia bajo la silueta del Puente Romano, donde la piedra antigua te invita a hacer una pausa.`,
 		area: "Centro-Este",
 		difficulty: DIFFICULTY_LEVELS.LOW,
 		time: "4 horas",


### PR DESCRIPTION
1. Refactor ThemeToggleButton to a named export and improve accessibility/behavior (aria-pressed, icon size, trimmed className, globalThis.setTimeout, transition-blocking comments). 
2. Update ThemeToggleButton styles (radius, transitions, focus ring, active state) and AboutUs/Hero copy tweaks (minor text adjustments). 
3. Replace default import/export for the theme toggle in index and update NavigationBar to import the named ThemeToggleButton and remove a global Themes.css import. 
4. Add generic CSS typings (declare "*.css") and tweak AboutUs icon font variable. 
5. Also adjust a mock excursion description wording in testserver data.