### PR TITLE
refactor: replace react-icons with lucide and refactor styles

### DIFF
--- a/excursiones/package-lock.json
+++ b/excursiones/package-lock.json
@@ -22,7 +22,6 @@
 				"react": "^18.2.0",
 				"react-bootstrap": "^2.10.9",
 				"react-dom": "^18.2.0",
-				"react-icons": "^5.4.0",
 				"react-loading-skeleton": "^3.5.0",
 				"react-redux": "^9.2.0",
 				"react-router-dom": "6.22.3",
@@ -18496,15 +18495,6 @@
 			"resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.10.tgz",
 			"integrity": "sha512-mKR90fX7Pm5seCOfz8q9F+66VCc1PGsWSBxKbITjfKVQHMNF2zudxHnMdJiB1fRCb+XsbQV9sO9DCkgsMQgBIA==",
 			"license": "MIT"
-		},
-		"node_modules/react-icons": {
-			"version": "5.6.0",
-			"resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.6.0.tgz",
-			"integrity": "sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA==",
-			"license": "MIT",
-			"peerDependencies": {
-				"react": "*"
-			}
 		},
 		"node_modules/react-is": {
 			"version": "17.0.2",

--- a/excursiones/package.json
+++ b/excursiones/package.json
@@ -17,7 +17,6 @@
 		"react": "^18.2.0",
 		"react-bootstrap": "^2.10.9",
 		"react-dom": "^18.2.0",
-		"react-icons": "^5.4.0",
 		"react-loading-skeleton": "^3.5.0",
 		"react-redux": "^9.2.0",
 		"react-router-dom": "6.22.3",

--- a/excursiones/src/components/AboutUs/AboutUs.tsx
+++ b/excursiones/src/components/AboutUs/AboutUs.tsx
@@ -12,9 +12,9 @@ const CONTENT = {
 
 export function AboutUs() {
 	return (
-		<section className="bg-card py-10 px-6" aria-labelledby="about-us-heading">
+		<section className="bg-card py-24 px-6" aria-labelledby="about-us-heading">
 			<div className="flex flex-col items-center text-center max-w-screen-xl mx-auto">
-				<div className="text-5xl mb-4 text-nature-600" aria-hidden="true">
+				<div className="text-5xl mb-4 text-primary" aria-hidden="true">
 					<BackpackIcon size={48} />
 				</div>
 				<div className="font-semibold tracking-[0.15em] text-xs uppercase text-muted-foreground mb-2">
@@ -25,7 +25,7 @@ export function AboutUs() {
 					className="font-light text-3xl md:text-4xl text-foreground leading-[1.1] tracking-tight text-balance mb-4"
 				>
 					{CONTENT.title.start}{" "}
-					<span className="font-semibold text-nature-600">
+					<span className="font-semibold text-primary">
 						{CONTENT.title.highlight}
 					</span>
 				</h2>

--- a/excursiones/src/components/Hero/Hero.tsx
+++ b/excursiones/src/components/Hero/Hero.tsx
@@ -29,17 +29,13 @@ export function Hero() {
 			aria-label="Cabecera principal con imagen de musgo"
 		>
 			<picture className="contents">
-				{/* Formato AVIF: Prioridad alta por ser más ligero */}
-				<source
-					srcSet={`${heroImageAvif} 1920w`}
-					sizes="100vw"
-					type="image/avif"
-				/>
+				{/* Si solo tenemos un archivo, evitamos engañar al srcSet para mantener la nitidez nativa */}
+				<source srcSet={heroImageAvif} type="image/avif" />
 				{/* Fallback: JPG original para navegadores que no soporten AVIF */}
 				<img
 					className="absolute inset-0 w-full h-full object-cover object-[center_16%] z-0"
 					src={heroImage}
-					alt=""
+					alt="Imagen de fondo de un sendero cubierto de musgo, evocando la conexión con la naturaleza y la aventura al aire libre."
 					loading="eager" // Prioridad alta para LCP
 					fetchPriority="high" // Refuerza la prioridad de carga
 					width={1920}

--- a/excursiones/src/css/Global.css
+++ b/excursiones/src/css/Global.css
@@ -1,9 +1,6 @@
 /* ======================================== */
 /* 0. RESET Y CONFIGURACIÓN GLOBAL */
 /* ======================================== */
-/* Tailwind ya incluye un reset (Preflight) muy potente, 
-   así que solo mantenemos lo que es específico de nuestra UX. */
-
 :root {
 	interpolate-size: allow-keywords; /* Mejora animaciones de height: auto */
 
@@ -11,6 +8,7 @@
 	--color-moss-100: 95 25% 88%;
 	--color-moss-300: 95 30% 60%;
 	--color-moss-500: 95 40% 40%;
+	--color-moss-600: 95 35% 34%;
 	--color-moss-700: 95 30% 28%;
 	--color-moss-800: 95 30% 23%;
 
@@ -48,14 +46,6 @@
 
 	/* Layout */
 	--navbar-height: 5rem;
-}
-
-/* Tipografía base fluida y accesible */
-body {
-	font-family: var(--font-sans);
-	-webkit-font-smoothing: antialiased;
-	-moz-osx-font-smoothing: grayscale;
-	text-rendering: optimizeLegibility;
 }
 
 /* Opt-out de animaciones en modo reducido por accesibilidad */

--- a/excursiones/src/css/Themes.css
+++ b/excursiones/src/css/Themes.css
@@ -1,7 +1,7 @@
 /* ======================================== */
-/* 2. TOKENS SEMÁNTICOS (EL CEREBRO DEL TEMA) */
+/* 2. TOKENS SEMÁNTICOS */
 /* ======================================== */
-html.light {
+:root {
 	color-scheme: light;
 	--background: var(--color-stone-50);
 	--foreground: var(--color-stone-900);
@@ -24,7 +24,7 @@ html.light {
 	--ring: var(--color-moss-700);
 }
 
-html.dark {
+.dark {
 	color-scheme: dark;
 	--background: var(--color-dark-900);
 	--foreground: var(--color-stone-50);
@@ -45,9 +45,4 @@ html.dark {
 	--border: var(--color-dark-500);
 	--input: var(--color-dark-500);
 	--ring: var(--color-moss-300);
-}
-
-/* Estilos Base de Aplicación que usan los tokens anteriores */
-body {
-	@apply bg-background text-foreground;
 }

--- a/excursiones/src/index.css
+++ b/excursiones/src/index.css
@@ -1,36 +1,21 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss/base";
+@import "./css/Global.css";
+@import "./css/Themes.css";
+@import "tailwindcss/components";
+@import "tailwindcss/utilities";
 
 :root {
-	/* Definimos las variables fuera de @layer para máxima compatibilidad */
-	--background: 40 30% 98%; /* #fdfcfb */
-	--foreground: 20 10% 20%; /* #333333 */
-
-	--primary: 113 39% 25%; /* #2d5a27 */
-	--primary-foreground: 40 30% 98%;
-
-	--card: 40 30% 98%;
-	--muted: 40 10% 90%;
-	--muted-foreground: var(--color-text-muted);
-
-	--border: 35 15% 92%; /* Crema muy suave para que sea casi invisible en claro */
-	--input: 20 10% 90%;
-	--ring: 113 39% 25%;
-
-	--radius: 0.75rem; /* 12px para ese look orgánico suave */
-}
-
-.dark {
-	--background: 95 25% 11%; /* var(--color-green-dark-900) - Musgo Profundo */
-	--foreground: 40 30% 98%;
-	--card: 95 20% 17%; /* var(--color-green-dark-800) - Verde musgo oscuro para el cuerpo */
-	--border: 95 25% 12%; /* Verde musgo casi negro para que se funda con el fondo */
+	--radius: 0.75rem;
 }
 
 @layer base {
 	body {
-		@apply bg-background text-foreground antialiased;
+		background-color: hsl(var(--background));
+		color: hsl(var(--foreground));
+		font-family: var(--font-sans);
+		-webkit-font-smoothing: antialiased;
+		-moz-osx-font-smoothing: grayscale;
+		text-rendering: optimizeLegibility;
 		font-feature-settings:
 			"rlig" 1,
 			"calt" 1;

--- a/excursiones/src/index.css
+++ b/excursiones/src/index.css
@@ -10,11 +10,8 @@
 
 @layer base {
 	body {
-		background-color: hsl(var(--background));
-		color: hsl(var(--foreground));
+		@apply bg-background text-foreground antialiased;
 		font-family: var(--font-sans);
-		-webkit-font-smoothing: antialiased;
-		-moz-osx-font-smoothing: grayscale;
 		text-rendering: optimizeLegibility;
 		font-feature-settings:
 			"rlig" 1,

--- a/excursiones/src/index.tsx
+++ b/excursiones/src/index.tsx
@@ -1,8 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import "bootstrap/dist/css/bootstrap.css";
-import "./css/Global.css";
-import "./css/Themes.css";
 /* index.css (Tailwind) debe ser el último para asegurar que sus 
    utilidades tengan prioridad sobre Bootstrap y estilos globales */
 import "./index.css";

--- a/excursiones/src/ui/Icons.tsx
+++ b/excursiones/src/ui/Icons.tsx
@@ -1,29 +1,29 @@
 import React from "react";
 import {
-	LuMountainSnow,
-	LuMoon,
-	LuSun,
-	LuLogIn,
-	LuCircleUser,
-	LuLogOut,
-	LuBackpack,
-	LuMapPin,
-	LuChartLine,
-	LuClock3,
-	LuSearch,
-	LuCheck,
-	LuImageOff,
-	LuCircleAlert,
-	LuTriangleAlert,
-	LuX,
-	LuEye,
-	LuEyeOff,
-	LuUser,
-	LuMail,
-	LuCopyright,
-	LuArrowUp,
-	LuLoader,
-} from "react-icons/lu";
+	MountainSnow,
+	Moon,
+	Sun,
+	LogIn,
+	CircleUser,
+	LogOut,
+	Backpack,
+	MapPin,
+	ChartLine,
+	Clock3,
+	Search,
+	Check,
+	ImageOff,
+	CircleAlert,
+	TriangleAlert,
+	X,
+	Eye,
+	EyeOff,
+	User,
+	Mail,
+	Copyright,
+	ArrowUp,
+	Loader,
+} from "lucide-react";
 
 // Tipo base para las props de los iconos
 type IconProps = {
@@ -36,49 +36,49 @@ type IconProps = {
  * Archivo central para exportar los componentes de íconos de la aplicación.
  */
 // Icono del logo
-export const LogoIcon = LuMountainSnow as React.ComponentType<IconProps>;
+export const LogoIcon = MountainSnow as React.ComponentType<IconProps>;
 // Icono de una luna para el botón de cambio de tema.
-export const MoonIcon = LuMoon as React.ComponentType<IconProps>;
+export const MoonIcon = Moon as React.ComponentType<IconProps>;
 // Icono de un sol para el cambio de tema.
-export const SunIcon = LuSun as React.ComponentType<IconProps>;
+export const SunIcon = Sun as React.ComponentType<IconProps>;
 // Icono para el inicio de sesión
-export const LoginIcon = LuLogIn as React.ComponentType<IconProps>;
+export const LoginIcon = LogIn as React.ComponentType<IconProps>;
 // Icono para el perfil de usuario
-export const ProfileIcon = LuCircleUser as React.ComponentType<IconProps>;
+export const ProfileIcon = CircleUser as React.ComponentType<IconProps>;
 // Icono para el cierre de sesión
-export const LogoutIcon = LuLogOut as React.ComponentType<IconProps>;
+export const LogoutIcon = LogOut as React.ComponentType<IconProps>;
 // Icono de mochila para la sección "Sobre Nosotros"
-export const BackpackIcon = LuBackpack as React.ComponentType<IconProps>;
+export const BackpackIcon = Backpack as React.ComponentType<IconProps>;
 // Icono de un pin para la zona.
-export const MapIcon = LuMapPin as React.ComponentType<IconProps>;
+export const MapIcon = MapPin as React.ComponentType<IconProps>;
 // Icono para la dificultad de las excursiones.
-export const ChartIcon = LuChartLine as React.ComponentType<IconProps>;
+export const ChartIcon = ChartLine as React.ComponentType<IconProps>;
 // Icono para el tiempo estimado de las excursiones.
-export const ClockIcon = LuClock3 as React.ComponentType<IconProps>;
+export const ClockIcon = Clock3 as React.ComponentType<IconProps>;
 // Icono de la lupa para la barra de búsqueda.
-export const SearchIcon = LuSearch as React.ComponentType<IconProps>;
+export const SearchIcon = Search as React.ComponentType<IconProps>;
 // Icono de check para éxito.
-export const CheckIcon = LuCheck as React.ComponentType<IconProps>;
+export const CheckIcon = Check as React.ComponentType<IconProps>;
 // Icono de alerta circular para errores.
-export const CircleAlertIcon = LuCircleAlert as React.ComponentType<IconProps>;
+export const CircleAlertIcon = CircleAlert as React.ComponentType<IconProps>;
 // Icono de alerta triangular.
 export const TriangleAlertIcon =
-	LuTriangleAlert as React.ComponentType<IconProps>;
+	TriangleAlert as React.ComponentType<IconProps>;
 // Icono de una "x" para limpiar la barra de búsqueda.
-export const XIcon = LuX as React.ComponentType<IconProps>;
+export const XIcon = X as React.ComponentType<IconProps>;
 // Icono para mostrar que la excursión no tiene imagen
-export const NoImageIcon = LuImageOff as React.ComponentType<IconProps>;
+export const NoImageIcon = ImageOff as React.ComponentType<IconProps>;
 // Icono de ojo para mostrar contraseña
-export const EyeIcon = LuEye as React.ComponentType<IconProps>;
+export const EyeIcon = Eye as React.ComponentType<IconProps>;
 // Icono de ojo tachado para ocultar contraseña
-export const EyeOffIcon = LuEyeOff as React.ComponentType<IconProps>;
+export const EyeOffIcon = EyeOff as React.ComponentType<IconProps>;
 // Icono de usuario para el perfil
-export const UserIcon = LuUser as React.ComponentType<IconProps>;
+export const UserIcon = User as React.ComponentType<IconProps>;
 // Icono de correo para el footer
-export const MailIcon = LuMail as React.ComponentType<IconProps>;
+export const MailIcon = Mail as React.ComponentType<IconProps>;
 // Icono del copyright para el footer
-export const CopyrightIcon = LuCopyright as React.ComponentType<IconProps>;
+export const CopyrightIcon = Copyright as React.ComponentType<IconProps>;
 // Icono de flecha hacia arriba para el botón de "Scroll to Top"
-export const ArrowUpIcon = LuArrowUp as React.ComponentType<IconProps>;
+export const ArrowUpIcon = ArrowUp as React.ComponentType<IconProps>;
 // Icono de carga para estados de espera (spinner)
-export const LoaderIcon = LuLoader as React.ComponentType<IconProps>;
+export const LoaderIcon = Loader as React.ComponentType<IconProps>;


### PR DESCRIPTION
1. Remove react-icons dependency and switch icon exports to lucide-react (Icons.tsx). 
2. Update AboutUs and Hero components: adjust spacing, use primary color token, improve AVIF <source> usage and add descriptive alt text. 
3. Consolidate and reorganize CSS: import Global.css/Themes.css from index.css, move base body styles into index.css, adjust theme token selectors (use :root/.dark), add a moss color token, and simplify Tailwind imports. 
4. Remove redundant CSS imports from index.tsx and update package.json/package-lock.json to drop react-icons.